### PR TITLE
fix: Rebase path not being generated properly

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -429,8 +429,12 @@ impl BuildCommand {
         trace!("BuildCommand::generate_full_image_name({recipe:#?})");
         info!("Generating full image name");
 
-        let image_name = if self.archive.is_some() {
-            recipe.name.to_string()
+        let image_name = if let Some(archive_dir) = &self.archive {
+            format!(
+                "oci-archive:{}/{}.{ARCHIVE_SUFFIX}",
+                archive_dir.to_string_lossy().trim_end_matches('/'),
+                recipe.name.to_lowercase(),
+            )
         } else {
             match (
                 env::var("CI_REGISTRY").ok(),
@@ -444,9 +448,9 @@ impl BuildCommand {
                     trace!("registry={registry}, registry_path={registry_path}");
                     format!(
                         "{}/{}/{}",
-                        registry.trim().trim_matches('/'),
-                        registry_path.trim().trim_matches('/'),
-                        &recipe.name
+                        registry.trim().trim_matches('/').to_lowercase(),
+                        registry_path.trim().trim_matches('/').to_lowercase(),
+                        recipe.name.trim().to_lowercase()
                     )
                 }
                 (
@@ -461,7 +465,7 @@ impl BuildCommand {
                     warn!("Generating Gitlab Registry image");
                     format!(
                         "{ci_registry}/{ci_project_namespace}/{ci_project_name}/{}",
-                        &recipe.name
+                        recipe.name.trim().to_lowercase()
                     )
                 }
                 (None, None, None, Some(github_repository_owner), None, None) => {
@@ -474,7 +478,7 @@ impl BuildCommand {
                     if self.push {
                         bail!("Need '--registry' and '--registry-path' in order to push image");
                     }
-                    recipe.name.clone()
+                    recipe.name.trim().to_lowercase()
                 }
             }
         };
@@ -490,12 +494,12 @@ impl BuildCommand {
     fn run_build(&self, image_name: &str, tags: &[String]) -> Result<()> {
         trace!("BuildCommand::run_build({image_name}, {tags:#?})");
 
-        let full_image = match &self.archive {
-            Some(archive_dir) => ops::generate_local_image_name(image_name, archive_dir.to_str()),
-            None => tags
-                .first()
+        let full_image = if self.archive.is_some() {
+            image_name.to_string()
+        } else {
+            tags.first()
                 .map(|t| format!("{image_name}:{t}"))
-                .unwrap_or(image_name.to_string()),
+                .unwrap_or(image_name.to_string())
         };
 
         info!("Building image {full_image}");

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -225,12 +225,7 @@ impl BuildCommand {
         let tags = recipe.generate_tags();
         let image_name = self.generate_full_image_name(&recipe)?;
         let first_image_name = match &self.archive {
-            Some(archive_dir) => format!(
-                "oci-archive:{}",
-                archive_dir
-                    .join(format!("{image_name}{ARCHIVE_SUFFIX}"))
-                    .display()
-            ),
+            Some(archive_dir) => ops::generate_local_image_name(&image_name, archive_dir.to_str()),
             None => tags
                 .first()
                 .map(|t| format!("{image_name}:{t}"))
@@ -496,12 +491,7 @@ impl BuildCommand {
         trace!("BuildCommand::run_build({image_name}, {tags:#?})");
 
         let full_image = match &self.archive {
-            Some(archive_dir) => format!(
-                "oci-archive:{}",
-                archive_dir
-                    .join(format!("{image_name}{ARCHIVE_SUFFIX}"))
-                    .display()
-            ),
+            Some(archive_dir) => ops::generate_local_image_name(image_name, archive_dir.to_str()),
             None => tags
                 .first()
                 .map(|t| format!("{image_name}:{t}"))

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -224,12 +224,12 @@ impl BuildCommand {
         // Get values for image
         let tags = recipe.generate_tags();
         let image_name = self.generate_full_image_name(&recipe)?;
-        let first_image_name = match &self.archive {
-            Some(archive_dir) => ops::generate_local_image_name(&image_name, archive_dir.to_str()),
-            None => tags
-                .first()
+        let first_image_name = if self.archive.is_some() {
+            image_name.to_string()
+        } else {
+            tags.first()
                 .map(|t| format!("{image_name}:{t}"))
-                .unwrap_or(image_name.to_string()),
+                .unwrap_or(image_name.to_string())
         };
         debug!("Full tag is {first_image_name}");
 

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -55,19 +55,17 @@ impl BlueBuildCommand for UpgradeCommand {
 
         build.try_run()?;
 
-        info!("Upgrading from locally built image {image_name}");
-
-        let image_name = format!("ostree-unverified-image:{image_name}");
+        let image_name = ops::generate_local_image_name(&image_name, Some(LOCAL_BUILD));
 
         let status = if self.common.reboot {
-            debug!("Upgrading image {image_name} and rebooting");
+            info!("Upgrading image {image_name} and rebooting");
 
             Command::new("rpm-ostree")
                 .arg("upgrade")
                 .arg("--reboot")
                 .status()?
         } else {
-            debug!("Upgrading image {image_name}");
+            info!("Upgrading image {image_name}");
 
             Command::new("rpm-ostree").arg("upgrade").status()?
         };
@@ -106,12 +104,10 @@ impl BlueBuildCommand for RebaseCommand {
 
         build.try_run()?;
 
-        info!("Rebasing onto locally built image {image_name}");
-
-        let image_name = format!("ostree-unverified-image:{image_name}");
+        let image_name = ops::generate_local_image_name(&image_name, Some(LOCAL_BUILD));
 
         let status = if self.common.reboot {
-            debug!("Rebasing image {image_name} and rebooting");
+            info!("Rebasing image {image_name} and rebooting");
 
             Command::new("rpm-ostree")
                 .arg("rebase")
@@ -119,7 +115,7 @@ impl BlueBuildCommand for RebaseCommand {
                 .arg(&image_name)
                 .status()?
         } else {
-            debug!("Rebasing image {image_name}");
+            info!("Rebasing image {image_name}");
 
             Command::new("rpm-ostree")
                 .arg("rebase")
@@ -156,7 +152,7 @@ fn clean_local_build_dir(image_name: &str, rebase: bool) -> Result<()> {
     trace!("clean_local_build_dir()");
 
     let local_build_path = Path::new(LOCAL_BUILD);
-    let image_file_name = format!("{image_name}.tar.gz");
+    let image_file_name = format!("{image_name}.{ARCHIVE_SUFFIX}");
     let image_file_path = local_build_path.join(image_file_name);
 
     if !image_file_path.exists() && !rebase {

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -55,8 +55,6 @@ impl BlueBuildCommand for UpgradeCommand {
 
         build.try_run()?;
 
-        let image_name = ops::generate_local_image_name(&image_name, Some(LOCAL_BUILD));
-
         let status = if self.common.reboot {
             info!("Upgrading image {image_name} and rebooting");
 
@@ -104,22 +102,20 @@ impl BlueBuildCommand for RebaseCommand {
 
         build.try_run()?;
 
-        let image_name = ops::generate_local_image_name(&image_name, Some(LOCAL_BUILD));
-
         let status = if self.common.reboot {
             info!("Rebasing image {image_name} and rebooting");
 
             Command::new("rpm-ostree")
                 .arg("rebase")
                 .arg("--reboot")
-                .arg(&image_name)
+                .arg(format!("ostree-unverified-image:{image_name}"))
                 .status()?
         } else {
             info!("Rebasing image {image_name}");
 
             Command::new("rpm-ostree")
                 .arg("rebase")
-                .arg(&image_name)
+                .arg(format!("ostree-unverified-image:{image_name}"))
                 .status()?
         };
 
@@ -152,8 +148,7 @@ fn clean_local_build_dir(image_name: &str, rebase: bool) -> Result<()> {
     trace!("clean_local_build_dir()");
 
     let local_build_path = Path::new(LOCAL_BUILD);
-    let image_file_name = format!("{image_name}.{ARCHIVE_SUFFIX}");
-    let image_file_path = local_build_path.join(image_file_name);
+    let image_file_path = local_build_path.join(image_name.trim_start_matches("oci-archive:"));
 
     if !image_file_path.exists() && !rebase {
         bail!(

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -24,14 +24,3 @@ pub fn check_command_exists(command: &str) -> Result<()> {
         ))
     }
 }
-
-pub fn generate_local_image_name(image_name: &str, directory: Option<&str>) -> String {
-    if let Some(directory) = directory {
-        format!(
-            "oci-archive:{}/{image_name}.{ARCHIVE_SUFFIX}",
-            directory.trim_end_matches('/')
-        )
-    } else {
-        format!("oci-archive:{image_name}.{ARCHIVE_SUFFIX}")
-    }
-}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,9 +1,9 @@
 use anyhow::{anyhow, Result};
 use log::{debug, trace};
-use std::process::Command;
+use std::{path::Path, process::Command};
 
 pub const LOCAL_BUILD: &str = "/etc/blue-build";
-pub const ARCHIVE_SUFFIX: &str = ".tar.gz";
+pub const ARCHIVE_SUFFIX: &str = "tar.gz";
 
 pub fn check_command_exists(command: &str) -> Result<()> {
     trace!("check_command_exists({command})");
@@ -22,5 +22,16 @@ pub fn check_command_exists(command: &str) -> Result<()> {
         Err(anyhow!(
             "Command {command} doesn't exist and is required to build the image"
         ))
+    }
+}
+
+pub fn generate_local_image_name(image_name: &str, directory: Option<&str>) -> String {
+    if let Some(directory) = directory {
+        format!(
+            "oci-archive:{}/{image_name}.{ARCHIVE_SUFFIX}",
+            directory.trim_end_matches('/')
+        )
+    } else {
+        format!("oci-archive:{image_name}.{ARCHIVE_SUFFIX}")
     }
 }


### PR DESCRIPTION
I move the format logic for appending the archive directory and the `oci-archive:` prefix in the `generate_full_image` function. This also fixes using the wrong string for the `rebase` command.