### PR TITLE
chore: use GHCR for install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo install --locked blue-build
 This will install the binary on your system in `/usr/local/bin`. This is only a `linux-gnu` version.
 
 ```bash
-podman run --rm registry.gitlab.com/wunker-bunker/blue-build:latest-installer | sudo bash
+podman run --rm ghcr.io/blue-build/cli:latest-installer | sudo bash
 ```
 
 ## How to use
@@ -97,7 +97,7 @@ variables:
       - "build-image"
 build-image:
   stage: build
-  image: registry.gitlab.com/wunker-bunker/blue-build:alpine
+  image: ghcr.io/blue-build/cli:alpine
   retry: 2
   rules:
     - if: $ACTION == "build-image"

--- a/install.sh
+++ b/install.sh
@@ -6,12 +6,12 @@ function cleanup() {
   echo "Cleaning up image"
   podman stop -i -t 0 blue-build-installer
   sleep 2
-  podman image rm ghcr.io/blue-build/cli:main-installer
+  podman image rm ghcr.io/blue-build/cli:latest-installer
 }
 
-podman pull ghcr.io/blue-build/cli:main-installer
+podman pull ghcr.io/blue-build/cli:latest-installer
 
-podman run -d --rm --name blue-build-installer ghcr.io/blue-build/cli:main-installer tail -f /dev/null
+podman run -d --rm --name blue-build-installer ghcr.io/blue-build/cli:latest-installer tail -f /dev/null
 
 set +e
 podman cp blue-build-installer:/out/bb /usr/local/bin/bb
@@ -22,7 +22,7 @@ set -e
 if [ -n $RETVAL ]; then
   cleanup
   echo "Failed to copy file, try:"
-  printf "\tpodman run --rm ghcr.io/blue-build/cli:main-installer | sudo bash\n"
+  printf "\tpodman run --rm ghcr.io/blue-build/cli:latest-installer | sudo bash\n"
   exit 1
 else
   cleanup

--- a/install.sh
+++ b/install.sh
@@ -6,12 +6,12 @@ function cleanup() {
   echo "Cleaning up image"
   podman stop -i -t 0 blue-build-installer
   sleep 2
-  podman image rm registry.gitlab.com/wunker-bunker/blue-build:latest-installer
+  podman image rm ghcr.io/blue-build/cli:main-installer
 }
 
-podman pull registry.gitlab.com/wunker-bunker/blue-build:latest-installer
+podman pull ghcr.io/blue-build/cli:main-installer
 
-podman run -d --rm --name blue-build-installer registry.gitlab.com/wunker-bunker/blue-build:latest-installer tail -f /dev/null
+podman run -d --rm --name blue-build-installer ghcr.io/blue-build/cli:main-installer tail -f /dev/null
 
 set +e
 podman cp blue-build-installer:/out/bb /usr/local/bin/bb
@@ -22,7 +22,7 @@ set -e
 if [ -n $RETVAL ]; then
   cleanup
   echo "Failed to copy file, try:"
-  printf "\tpodman run --rm registry.gitlab.com/wunker-bunker/blue-build:latest-installer | sudo bash\n"
+  printf "\tpodman run --rm ghcr.io/blue-build/cli:main-installer | sudo bash\n"
   exit 1
 else
   cleanup

--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -21,7 +21,7 @@ COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
 
 COPY --from=gcr.io/projectsigstore/cosign /ko-app/cosign /usr/bin/cosign
 
-COPY --from=registry.gitlab.com/wunker-bunker/blue-build:
+COPY --from=ghcr.io/blue-build/cli:
 {%- if let Some(tag) = recipe.blue_build_tag -%}
 {{ tag }}
 {%- else -%}


### PR DESCRIPTION
Trying to make the action install the binary from the container on GHCR with `podman run --rm ghcr.io/blue-build/cli:main-installer | sudo bash` (like in the README). Getting some error and this _might_ be related and might not, but shouldn't hurt to merge either, since I just made the `cli` package public.