### PR TITLE
chore: Setup earthly satellite building

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # There is a bug selecting a satellite in version 0.8
+      # so we use 0.7 to login and connect to the satellite
+      # before switching to the latest version
       - uses: earthly/actions-setup@v1
         with:
           version: v0.7.23
@@ -23,6 +26,7 @@ jobs:
           earthly sat s blue-build-pr
 
       - uses: earthly/actions-setup@v1
+
         with:
           version: v0.8.2
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: earthly/actions-setup@v1
-
       - name: Earthly login
         run: |
+          wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
           earthly org s blue-build
           earthly sat s blue-build-pr
+          earthly bootstrap
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,13 +13,18 @@ jobs:
 
     steps:
       - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.23
 
       - name: Earthly login
         run: |
-          earthly bootstrap
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-pr
+
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.2
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: earthly/actions-setup@v1
+
       - name: Earthly login
         run: |
-          wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
+          earthly bootstrap
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
           earthly org s blue-build
           earthly sat s blue-build-pr
-          earthly bootstrap
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,11 +13,13 @@ jobs:
 
     steps:
       - uses: earthly/actions-setup@v1
-        with:
-          use-cache: true
-          version: v0.8.2
 
-      # Setup repo and add caching
+      - name: Earthly login
+        run: |
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
+          earthly org s blue-build
+          earthly sat s blue-build-pr
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: earthly/actions-setup@v1
+
       - name: Earthly login
         run: |
-          wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
+          earthly bootstrap
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
           earthly org s blue-build
           earthly sat s blue-build
-          earthly bootstrap
 
       # Setup repo and add caching
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,18 @@ jobs:
 
     steps:
       - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.23
 
       - name: Earthly login
         run: |
-          earthly bootstrap
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build
+
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.2
 
       # Setup repo and add caching
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # There is a bug selecting a satellite in version 0.8
+      # so we use 0.7 to login and connect to the satellite
+      # before switching to the latest version
       - uses: earthly/actions-setup@v1
         with:
           version: v0.7.23

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: earthly/actions-setup@v1
-
       - name: Earthly login
         run: |
+          wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
           earthly org s blue-build
           earthly sat s blue-build
+          earthly bootstrap
 
       # Setup repo and add caching
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Earthly main branch +build
+name: Earthly main branch +all
 
 on:
   workflow_dispatch:
@@ -47,4 +47,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run build
-        run: earthly --push --ci -P +build
+        run: earthly --push --ci -P +all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,12 @@ jobs:
 
     steps:
       - uses: earthly/actions-setup@v1
-        with:
-          use-cache: true
-          version: v0.8.2
+
+      - name: Earthly login
+        run: |
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
+          earthly org s blue-build
+          earthly sat s blue-build
 
       # Setup repo and add caching
       - uses: actions/checkout@v4

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,6 +23,9 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.GIT_REPO_TOKEN }}
 
+      # There is a bug selecting a satellite in version 0.8
+      # so we use 0.7 to login and connect to the satellite
+      # before switching to the latest version
       - uses: earthly/actions-setup@v1
         with:
           version: v0.7.23

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -26,9 +26,12 @@ jobs:
       #Deps
       - name: Set up Earthly
         uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.0
-          use-cache: true
+
+      - name: Earthly login
+        run: |
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
+          earthly org s blue-build
+          earthly sat s blue-build
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
-          earthly sat s blue-build-pr
+          earthly sat s blue-build
 
       - uses: earthly/actions-setup@v1
         with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -23,16 +23,19 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.GIT_REPO_TOKEN }}
 
-      #Deps
-      - name: Set up Earthly
-        uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.23
 
       - name: Earthly login
         run: |
-          earthly bootstrap
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
-          earthly sat s blue-build
+          earthly sat s blue-build-pr
+
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.2
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,19 +16,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Setup repo and add caching
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GIT_REPO_TOKEN }}
 
+      #Deps
+      - name: Set up Earthly
+        uses: earthly/actions-setup@v1
+
       - name: Earthly login
         run: |
-          wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
+          earthly bootstrap
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
           earthly org s blue-build
           earthly sat s blue-build
-          earthly bootstrap
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,22 +16,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Setup repo and add caching
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GIT_REPO_TOKEN }}
 
-      #Deps
-      - name: Set up Earthly
-        uses: earthly/actions-setup@v1
-
       - name: Earthly login
         run: |
+          wget https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }}
           earthly org s blue-build
           earthly sat s blue-build
+          earthly bootstrap
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,5 @@
 VERSION 0.8
+PROJECT blue-build/cli
 
 IMPORT github.com/blue-build/earthly-lib/cargo AS cargo
 


### PR DESCRIPTION
- Builds on main and tags will use the `medium` satellite that uses `x4` rate on build minutes
  - This gives us larger cache and more memory
- Builds on PRs will use the `small` satellite that uses `x2` rate on build minutes
- We are using the starter tier which gives us `10000` build minutes per month and caching for our builds to make them faster