### PR TITLE
fix: allow for image registry variables for local builds

### DIFF
--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -6,10 +6,8 @@ LABEL io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-
 LABEL io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
 
 ARG RECIPE={{ recipe_path.display() }}
-{%- if self::running_gitlab_actions() %}
 ARG IMAGE_REGISTRY=ghcr.io/ublue-os
 COPY cosign.pub /usr/share/ublue-os/cosign.pub
-{%- endif %}
 
 # Copy the bling from ublue-os/bling into tmp, to be installed later by the bling module
 # Feel free to remove these lines if you want to speed up image builds and don't want any bling


### PR DESCRIPTION
 For local builds, this is needed to sign