### PR TITLE
fix: remove deprecated bling `COPY` for `files` and `rpms`

### DIFF
--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -19,10 +19,6 @@ ARG IMAGE_REGISTRY=localhost
 COPY cosign.pub /usr/share/ublue-os/cosign.pub
 {%- endif %}
 
-# Copy the bling from ublue-os/bling into tmp, to be installed later by the bling module
-# Feel free to remove these lines if you want to speed up image builds and don't want any bling
-COPY --from=ghcr.io/ublue-os/bling:latest /rpms /tmp/bling/rpms
-COPY --from=ghcr.io/ublue-os/bling:latest /files /tmp/bling/files
 COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
 COPY --from=gcr.io/projectsigstore/cosign /ko-app/cosign /usr/bin/cosign
 


### PR DESCRIPTION
https://github.com/ublue-os/bling/blob/main/Containerfile the containerfile copies an empty folder in these locations for backwards compatability. `/tmp/files` and `/tmp/rpms` have been deprecated from bling, all of the RPMs have mostly moved to COPR or ublue-os/config