### PR TITLE
fix: only use earthly builder if token exists

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,7 +17,7 @@ jobs:
           version: v0.8.3
 
       - name: Earthly login
-        if: secrets.EARTHLY_SAT_TOKEN != ""
+        if: ${{ secrets.EARTHLY_SAT_TOKEN }} != ""
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,6 +17,7 @@ jobs:
           version: v0.8.3
 
       - name: Earthly login
+        if: secrets.EARTHLY_SAT_TOKEN != ""
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,7 +17,9 @@ jobs:
           version: v0.8.3
 
       - name: Earthly login
-        if: ${{ secrets.EARTHLY_SAT_TOKEN }} != ""
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build


### PR DESCRIPTION
This fixes workflow runs from PRs that use forks of the repo and don't contain the secret for the earthly login