### PR TITLE
fix: Rebase/Upgrade not using local image cache

### DIFF
--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -50,7 +50,7 @@ impl BlueBuildCommand for UpgradeCommand {
             .archive(LOCAL_BUILD)
             .build();
 
-        let image_name = build.generate_full_image_name(&recipe)?;
+        let image_name = format!("{}.tar.gz", build.generate_full_image_name(&recipe)?);
         clean_local_build_dir(&image_name, false)?;
         debug!("Image name is {image_name}");
 
@@ -97,7 +97,7 @@ impl BlueBuildCommand for RebaseCommand {
             .archive(LOCAL_BUILD)
             .build();
 
-        let image_name = build.generate_full_image_name(&recipe)?;
+        let image_name = format!("{}.tar.gz", build.generate_full_image_name(&recipe)?);
         clean_local_build_dir(&image_name, true)?;
         debug!("Image name is {image_name}");
 

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -50,7 +50,10 @@ impl BlueBuildCommand for UpgradeCommand {
             .archive(LOCAL_BUILD)
             .build();
 
-        let image_name = format!("{}.tar.gz", build.generate_full_image_name(&recipe)?);
+        let image_name = format!(
+            "{}.{ARCHIVE_SUFFIX}",
+            build.generate_full_image_name(&recipe)?
+        );
         clean_local_build_dir(&image_name, false)?;
         debug!("Image name is {image_name}");
 
@@ -97,7 +100,10 @@ impl BlueBuildCommand for RebaseCommand {
             .archive(LOCAL_BUILD)
             .build();
 
-        let image_name = format!("{}.tar.gz", build.generate_full_image_name(&recipe)?);
+        let image_name = format!(
+            "{}.{ARCHIVE_SUFFIX}",
+            build.generate_full_image_name(&recipe)?
+        );
         clean_local_build_dir(&image_name, true)?;
         debug!("Image name is {image_name}");
 


### PR DESCRIPTION
When building an image directly to an oci-archive, podman and buildah wouldn't use any of the cache in the local registry. This fix makes it so that it will build the image in the local registry and then export it to a local archive file.