### PR TITLE
feat: use WORKDIR and ENTRYPOINT for cli containers

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -79,7 +79,7 @@ blue-build-cli:
 
 	RUN mkdir -p /bluebuild
 	WORKDIR /bluebuild
-	CMD bluebuild
+	ENTRYPOINT ["bluebuild"]
 
 	DO cargo+SAVE_IMAGE --IMAGE=$IMAGE --TAG=$TAG --LATEST=$LATEST --NIGHTLY=$NIGHTLY
 
@@ -99,7 +99,7 @@ blue-build-cli-alpine:
 
 	RUN mkdir -p /bluebuild
 	WORKDIR /bluebuild
-	CMD bluebuild
+	ENTRYPOINT ["bluebuild"]
 
 	DO cargo+SAVE_IMAGE --IMAGE=$IMAGE --TAG=$TAG --LATEST=$LATEST --NIGHTLY=$NIGHTLY --ALPINE=true
 

--- a/Earthfile
+++ b/Earthfile
@@ -76,6 +76,11 @@ blue-build-cli:
 
 	ARG TAG
 	ARG LATEST=false
+
+	RUN mkdir -p /bluebuild
+	WORKDIR /bluebuild
+	CMD bluebuild
+
 	DO cargo+SAVE_IMAGE --IMAGE=$IMAGE --TAG=$TAG --LATEST=$LATEST --NIGHTLY=$NIGHTLY
 
 blue-build-cli-alpine:
@@ -91,6 +96,11 @@ blue-build-cli-alpine:
 
 	ARG TAG
 	ARG LATEST=false
+
+	RUN mkdir -p /bluebuild
+	WORKDIR /bluebuild
+	CMD bluebuild
+
 	DO cargo+SAVE_IMAGE --IMAGE=$IMAGE --TAG=$TAG --LATEST=$LATEST --NIGHTLY=$NIGHTLY --ALPINE=true
 
 installer:


### PR DESCRIPTION
required for running the bluebuild CLI directly from podman (needed for latest version of bluebuild for github action)