### PR TITLE
feat: Use tmpfs mount for /tmp and /var

### DIFF
--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -72,6 +72,8 @@ COPY {{ src }} {{ dest }}
 			{%- endif %}
 		{%- else %}
 RUN \
+	--mount=type=tmpfs,target=/tmp \
+	--mount=type=tmpfs,target=/var \
 	--mount=type=bind,from=stage-config,src=/config,dst=/tmp/config,rw \
 	--mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
 	--mount=type=bind,from=stage-exports,src=/exports.sh,dst=/tmp/exports.sh \
@@ -81,5 +83,4 @@ RUN \
   {%- endif %}
 {%- endfor %}
 
-
-RUN rm -rf /tmp/* /var/* && ostree container commit
+RUN ostree container commit


### PR DESCRIPTION
This allows scripts to create as many files as they need in /tmp and /var without having to worry about them being included in the final image. Now the last instruction will only be the ostree container commit