### PR TITLE
feat: Make use of rpm-ostree cache

### DIFF
--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -81,7 +81,7 @@ RUN \
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
       {%- endif %}
   --mount=type=bind,from=stage-exports,src=/exports.sh,dst=/tmp/exports.sh \
-	--mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
+  --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
   chmod +x /tmp/modules/{{ type }}/{{ type }}.sh \
   && source /tmp/exports.sh && /tmp/modules/{{ type }}/{{ type }}.sh '{{ self::print_module_context(module) }}'
     {%- endif %}

--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -77,7 +77,7 @@ RUN \
 	--mount=type=bind,from=stage-config,src=/config,dst=/tmp/config,rw \
 	--mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
 	--mount=type=bind,from=stage-exports,src=/exports.sh,dst=/tmp/exports.sh \
-	--mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }} \
+	--mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
 	chmod +x /tmp/modules/{{ type }}/{{ type }}.sh \
 	&& source /tmp/exports.sh && /tmp/modules/{{ type }}/{{ type }}.sh '{{ self::print_module_context(module) }}'
 		{%- endif %}

--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -77,6 +77,7 @@ RUN \
 	--mount=type=bind,from=stage-config,src=/config,dst=/tmp/config,rw \
 	--mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
 	--mount=type=bind,from=stage-exports,src=/exports.sh,dst=/tmp/exports.sh \
+	--mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }} \
 	chmod +x /tmp/modules/{{ type }}/{{ type }}.sh \
 	&& source /tmp/exports.sh && /tmp/modules/{{ type }}/{{ type }}.sh '{{ self::print_module_context(module) }}'
 		{%- endif %}


### PR DESCRIPTION
After setting up the tmpfs mount for /var, rpm-ostree started to not have cache throughout the single build. This creates a cache for rpm-ostree that is tied to the specific recipe being built. This will allow subsequent builds of a recipe to be faster and not interfere with the cache of another recipe, especially if they are on different OS versions