### PR TITLE
fix: Remove trailing newlines from yaml arrays

### DIFF
--- a/templates/export.sh
+++ b/templates/export.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 get_yaml_array() { 
-  readarray "$1" < <(echo "$3" | yq -I=0 "$2")
+  readarray -t "$1" < <(echo "$3" | yq -I=0 "$2")
 } 
 
 export -f get_yaml_array


### PR DESCRIPTION
Trailing newlines is something that we will never need as an information, so it can only cause issues with parsing yaml values.

I scratched my head for 10 minutes on why my variable has a trailing newline when I use `readarray -t` everywhere. Then I remembered get_yaml_array function.

This should not affect current working modules at all, but it would be good to test before landing.