### PR TITLE
refactor: Use GITHUB_TOKEN instead of REGISTRY_TOKEN

### DIFF
--- a/src/commands/bug_report.rs
+++ b/src/commands/bug_report.rs
@@ -1,6 +1,3 @@
-use crate::module_recipe::Recipe;
-use crate::shadow;
-
 use askama::Template;
 use clap::Args;
 use clap_complete::Shell;
@@ -14,10 +11,7 @@ use typed_builder::TypedBuilder;
 use super::utils::exec_cmd;
 use super::BlueBuildCommand;
 
-const UNKNOWN_SHELL: &str = "<unknown shell>";
-const UNKNOWN_VERSION: &str = "<unknown version>";
-const UNKNOWN_TERMINAL: &str = "<unknown terminal>";
-const GITHUB_CHAR_LIMIT: usize = 8100; // Magic number accepted by Github
+use crate::{constants::*, module_recipe::Recipe, shadow};
 
 #[derive(Default, Debug, Clone, TypedBuilder, Args)]
 pub struct BugReportRecipe {
@@ -232,12 +226,12 @@ struct TerminalInfo {
 }
 
 fn get_terminal_info() -> TerminalInfo {
-    let terminal = std::env::var("TERM_PROGRAM")
-        .or_else(|_| std::env::var("LC_TERMINAL"))
+    let terminal = std::env::var(TERM_PROGRAM)
+        .or_else(|_| std::env::var(LC_TERMINAL))
         .unwrap_or_else(|_| UNKNOWN_TERMINAL.to_string());
 
-    let version = std::env::var("TERM_PROGRAM_VERSION")
-        .or_else(|_| std::env::var("LC_TERMINAL_VERSION"))
+    let version = std::env::var(TERM_PROGRAM_VERSION)
+        .or_else(|_| std::env::var(LC_TERMINAL_VERSION))
         .unwrap_or_else(|_| UNKNOWN_VERSION.to_string());
 
     TerminalInfo {

--- a/src/commands/build/build_strategy.rs
+++ b/src/commands/build/build_strategy.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{bail, Result};
 use log::trace;
 
-use crate::ops;
+use crate::{constants::*, ops};
 
 #[cfg(feature = "podman-api")]
 #[derive(Debug, Clone, Default)]
@@ -25,10 +25,10 @@ impl BuildStrategy {
 
         Ok(
             match (
-                env::var("XDG_RUNTIME_DIR"),
-                PathBuf::from("/run/podman/podman.sock"),
-                PathBuf::from("/var/run/podman/podman.sock"),
-                PathBuf::from("/var/run/podman.sock"),
+                env::var(XDG_RUNTIME_DIR),
+                PathBuf::from(RUN_PODMAN_SOCK),
+                PathBuf::from(VAR_RUN_PODMAN_PODMAN_SOCK),
+                PathBuf::from(VAR_RUN_PODMAN_SOCK),
                 ops::check_command_exists("buildah"),
                 ops::check_command_exists("podman"),
             ) {

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -12,8 +12,9 @@ use users::{Users, UsersCache};
 
 use crate::{
     commands::build::BuildCommand,
+    constants::{ARCHIVE_SUFFIX, LOCAL_BUILD},
     module_recipe::Recipe,
-    ops::{self, ARCHIVE_SUFFIX, LOCAL_BUILD},
+    ops,
 };
 
 use super::BlueBuildCommand;

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -12,7 +12,7 @@ use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 use crate::{
-    constants::{self},
+    constants::*,
     module_recipe::{Module, Recipe},
 };
 
@@ -60,7 +60,7 @@ impl BlueBuildCommand for TemplateCommand {
             "Templating for recipe at {}",
             self.recipe
                 .clone()
-                .unwrap_or_else(|| PathBuf::from(constants::RECIPE_PATH))
+                .unwrap_or_else(|| PathBuf::from(RECIPE_PATH))
                 .display()
         );
 
@@ -77,7 +77,7 @@ impl TemplateCommand {
         let recipe_path = self
             .recipe
             .clone()
-            .unwrap_or_else(|| PathBuf::from(constants::RECIPE_PATH));
+            .unwrap_or_else(|| PathBuf::from(RECIPE_PATH));
 
         debug!("Deserializing recipe");
         let recipe_de = Recipe::parse(&recipe_path)?;
@@ -133,7 +133,7 @@ fn print_script(script_contents: &ExportsTemplate) -> String {
 fn has_cosign_file() -> bool {
     trace!("has_cosign_file()");
     std::env::current_dir()
-        .map(|p| p.join(constants::COSIGN_PATH).exists())
+        .map(|p| p.join(COSIGN_PATH).exists())
         .unwrap_or(false)
 }
 
@@ -208,16 +208,16 @@ fn get_files_list(module: &Module) -> Option<Vec<(String, String)>> {
 }
 
 fn get_github_repo_owner() -> Option<String> {
-    Some(env::var("GITHUB_REPOSITORY_OWNER").ok()?.to_lowercase())
+    Some(env::var(GITHUB_REPOSITORY_OWNER).ok()?.to_lowercase())
 }
 
 fn get_gitlab_registry_path() -> Option<String> {
     Some(
         format!(
             "{}/{}/{}",
-            env::var("CI_REGISTRY").ok()?,
-            env::var("CI_PROJECT_NAMESPACE").ok()?,
-            env::var("CI_PROJECT_NAME").ok()?,
+            env::var(CI_REGISTRY).ok()?,
+            env::var(CI_PROJECT_NAMESPACE).ok()?,
+            env::var(CI_PROJECT_NAME).ok()?,
         )
         .to_lowercase(),
     )

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,56 @@
+// Paths
+pub const ARCHIVE_SUFFIX: &str = "tar.gz";
 pub const COSIGN_PATH: &str = "./cosign.pub";
+pub const LOCAL_BUILD: &str = "/etc/bluebuild";
 pub const MODULES_PATH: &str = "./config/modules";
 pub const RECIPE_PATH: &str = "./config/recipe.yml";
+pub const RUN_PODMAN_SOCK: &str = "/run/podman/podman.sock";
+pub const VAR_RUN_PODMAN_PODMAN_SOCK: &str = "/var/run/podman/podman.sock";
+pub const VAR_RUN_PODMAN_SOCK: &str = "/var/run/podman.sock";
+
+// Labels
+pub const BUILD_ID_LABEL: &str = "org.blue-build.build-id";
+
+// Cosign vars
+pub const COSIGN_PRIVATE_KEY: &str = "COSIGN_PRIVATE_KEY";
 pub const GITHUB_TOKEN_ISSUER_URL: &str = "https://token.actions.githubusercontent.com";
+pub const SIGSTORE_ID_TOKEN: &str = "SIGSTORE_ID_TOKEN";
+
+// GitHub CI vars
+pub const GITHUB_ACTIONS: &str = "GITHUB_ACTIONS";
+pub const GITHUB_ACTOR: &str = "GITHUB_ACTOR";
+pub const GITHUB_EVENT_NAME: &str = "GITHUB_EVENT_NAME";
+pub const GITHUB_REF_NAME: &str = "GITHUB_REF_NAME";
+pub const GITHUB_REPOSITORY_OWNER: &str = "GITHUB_REPOSITORY_OWNER";
+pub const GITHUB_SHA: &str = "GITHUB_SHA";
+pub const GITHUB_TOKEN: &str = "GITHUB_TOKEN";
+pub const GITHUB_WORKFLOW_REF: &str = "GITHUB_WORKFLOW_REF";
+pub const PR_EVENT_NUMBER: &str = "PR_EVENT_NUMBER";
+
+// GitLab CI vars
+pub const CI_COMMIT_REF_NAME: &str = "CI_COMMIT_REF_NAME";
+pub const CI_COMMIT_SHORT_SHA: &str = "CI_COMMIT_SHORT_SHA";
+pub const CI_DEFAULT_BRANCH: &str = "CI_DEFAULT_BRANCH";
+pub const CI_MERGE_REQUEST_IID: &str = "CI_MERGE_REQUEST_IID";
+pub const CI_PIPELINE_SOURCE: &str = "CI_PIPELINE_SOURCE";
+pub const CI_PROJECT_NAME: &str = "CI_PROJECT_NAME";
+pub const CI_PROJECT_NAMESPACE: &str = "CI_PROJECT_NAMESPACE";
+pub const CI_PROJECT_URL: &str = "CI_PROJECT_URL";
+pub const CI_SERVER_HOST: &str = "CI_SERVER_HOST";
+pub const CI_SERVER_PROTOCOL: &str = "CI_SERVER_PROTOCOL";
+pub const CI_REGISTRY: &str = "CI_REGISTRY";
+pub const CI_REGISTRY_PASSWORD: &str = "CI_REGISTRY_PASSWORD";
+pub const CI_REGISTRY_USER: &str = "CI_REGISTRY_USER";
+
+// Terminal vars
+pub const TERM_PROGRAM: &str = "TERM_PROGRAM";
+pub const LC_TERMINAL: &str = "LC_TERMINAL";
+pub const TERM_PROGRAM_VERSION: &str = "TERM_PROGRAM_VERSION";
+pub const LC_TERMINAL_VERSION: &str = "LC_TERMINAL_VERSION";
+pub const XDG_RUNTIME_DIR: &str = "XDG_RUNTIME_DIR";
+
+// Misc
+pub const UNKNOWN_SHELL: &str = "<unknown shell>";
+pub const UNKNOWN_VERSION: &str = "<unknown version>";
+pub const UNKNOWN_TERMINAL: &str = "<unknown terminal>";
+pub const GITHUB_CHAR_LIMIT: usize = 8100; // Magic number accepted by Github

--- a/src/module_recipe.rs
+++ b/src/module_recipe.rs
@@ -16,7 +16,10 @@ use serde_json::Value as JsonValue;
 use serde_yaml::Value;
 use typed_builder::TypedBuilder;
 
-use crate::ops::{self, check_command_exists};
+use crate::{
+    constants::*,
+    ops::{self, check_command_exists},
+};
 
 #[derive(Default, Serialize, Clone, Deserialize, Debug, TypedBuilder)]
 pub struct Recipe<'a> {
@@ -57,15 +60,15 @@ impl<'a> Recipe<'a> {
         let timestamp = Local::now().format("%Y%m%d").to_string();
 
         if let (Ok(commit_branch), Ok(default_branch), Ok(commit_sha), Ok(pipeline_source)) = (
-            env::var("CI_COMMIT_REF_NAME"),
-            env::var("CI_DEFAULT_BRANCH"),
-            env::var("CI_COMMIT_SHORT_SHA"),
-            env::var("CI_PIPELINE_SOURCE"),
+            env::var(CI_COMMIT_REF_NAME),
+            env::var(CI_DEFAULT_BRANCH),
+            env::var(CI_COMMIT_SHORT_SHA),
+            env::var(CI_PIPELINE_SOURCE),
         ) {
             trace!("CI_COMMIT_REF_NAME={commit_branch}, CI_DEFAULT_BRANCH={default_branch},CI_COMMIT_SHORT_SHA={commit_sha}, CI_PIPELINE_SOURCE={pipeline_source}");
             warn!("Detected running in Gitlab, pulling information from CI variables");
 
-            if let Ok(mr_iid) = env::var("CI_MERGE_REQUEST_IID") {
+            if let Ok(mr_iid) = env::var(CI_MERGE_REQUEST_IID) {
                 trace!("CI_MERGE_REQUEST_IID={mr_iid}");
                 if pipeline_source == "merge_request_event" {
                     debug!("Running in a MR");
@@ -91,10 +94,10 @@ impl<'a> Recipe<'a> {
             Ok(github_sha),
             Ok(github_ref_name),
         ) = (
-            env::var("GITHUB_EVENT_NAME"),
-            env::var("PR_EVENT_NUMBER"),
-            env::var("GITHUB_SHA"),
-            env::var("GITHUB_REF_NAME"),
+            env::var(GITHUB_EVENT_NAME),
+            env::var(PR_EVENT_NUMBER),
+            env::var(GITHUB_SHA),
+            env::var(GITHUB_REF_NAME),
         ) {
             trace!("GITHUB_EVENT_NAME={github_event_name},PR_EVENT_NUMBER={github_event_number},GITHUB_SHA={github_sha},GITHUB_REF_NAME={github_ref_name}");
             warn!("Detected running in Github, pulling information from GITHUB variables");

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,10 +3,6 @@ use format_serde_error::SerdeError;
 use log::{debug, trace};
 use std::process::Command;
 
-pub const LOCAL_BUILD: &str = "/etc/bluebuild";
-pub const ARCHIVE_SUFFIX: &str = "tar.gz";
-pub const BUILD_ID_LABEL: &str = "org.blue-build.build-id";
-
 pub fn check_command_exists(command: &str) -> Result<()> {
     trace!("check_command_exists({command})");
     debug!("Checking if {command} exists");

--- a/templates/Containerfile
+++ b/templates/Containerfile
@@ -18,7 +18,7 @@ RUN printf {{ self::print_script(export_script) }} >> /exports.sh && chmod +x /e
 
 FROM {{ recipe.base_image }}:{{ recipe.image_version }}
 
-LABEL {{ crate::ops::BUILD_ID_LABEL }}="{{ build_id }}"
+LABEL {{ crate::constants::BUILD_ID_LABEL }}="{{ build_id }}"
 LABEL org.opencontainers.image.title="{{ recipe.name }}"
 LABEL org.opencontainers.image.description="{{ recipe.description }}"
 LABEL io.artifacthub.package.readme-url=https://raw.githubusercontent.com/blue-build/cli/main/README.md


### PR DESCRIPTION
To keep things as consistent as possible, we're switching to using the GITHUB_TOKEN env var for login instead. Env vars were also all pulled out into their own constants to make things more consistent.

This change also includes prioritizing public/private key signing over OIDC keyless for GitHub for an easier transition. It would require the user to delete their `cosign.pub` file from their repo in order to start using the keyless method.