### PR TITLE
feat: add retry options to cli build command

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -71,6 +71,7 @@ pub struct BuildCommand {
     #[arg(short, long, default_value_t = true)]
     #[builder(default)]
     retry_push: bool,
+
     /// The number of times to retry pushing the image.
     #[arg(long, default_value_t = 1)]
     #[builder(default)]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -67,6 +67,15 @@ pub struct BuildCommand {
     #[builder(default)]
     push: bool,
 
+    /// Allow `bluebuild` to retry pushing images if it fails.
+    #[arg(short, long, default_value_t = true)]
+    #[builder(default)]
+    retry_push: bool,
+    /// The number of times to retry pushing the image.
+    #[arg(long, default_value_t = 1)]
+    #[builder(default)]
+    retry_count: u8,
+
     /// Allow `bluebuild` to overwrite an existing
     /// Containerfile without confirmation.
     ///
@@ -574,7 +583,11 @@ impl BuildCommand {
         }
 
         if self.push {
-            push_images(tags, image_name)?;
+            let retry = self.retry_push;
+            let retry_count = if retry { self.retry_count } else { 0 };
+
+            // Push images with retries (1s delay between retries)
+            ops::retry(retry_count, 1000, || push_images(tags, image_name))?;
             sign_images(image_name, tags.first().map(String::as_str))?;
         }
 


### PR DESCRIPTION
An issue was filed for adding retry logic to our push_image command in the CLI. https://github.com/blue-build/cli/issues/79.

This PR adds:
- **retry flag**
  - `-r`
  - defaults to true 
- **retry_count flag**
  - `--retry_count`
  - defaults to 1

This functionality will be extended to our other services in build (podman api as well once that is hooked up), but this is the initial ground work