### PR TITLE
fix: Run `ostree container commit` at the end of each module run

### DIFF
--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -48,9 +48,6 @@ ARG BASE_IMAGE="{{ recipe.base_image }}"
 
 COPY --from=gcr.io/projectsigstore/cosign /ko-app/cosign /usr/bin/cosign
 COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
-
-{%- include "modules/modules.j2" %}
-
 COPY --from=ghcr.io/blue-build/cli:
 {%- if let Some(tag) = recipe.blue_build_tag -%}
 {{ tag }}
@@ -58,4 +55,8 @@ COPY --from=ghcr.io/blue-build/cli:
 latest-installer
 {%- endif %} /out/bluebuild /usr/bin/bluebuild
 
-RUN ostree container commit
+{%- include "modules/modules.j2" %}
+
+# Added in case a user adds something else using the
+# 'containerfile' module
+RUN rm -fr /tmp/* /var/* && ostree container commit

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -20,7 +20,8 @@ RUN \
   --mount=type=bind,from=stage-exports,src=/exports.sh,dst=/tmp/exports.sh \
   --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
   chmod +x /tmp/modules/{{ type }}/{{ type }}.sh \
-  && source /tmp/exports.sh && /tmp/modules/{{ type }}/{{ type }}.sh '{{ module.print_module_context() }}'
+  && source /tmp/exports.sh && /tmp/modules/{{ type }}/{{ type }}.sh '{{ module.print_module_context() }}' \
+  && ostree container commit
     {%- endif %}
   {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
Since the command `ostree container commit` checks for the presence of mounted directories, we will be running it at the end of each module run. We have also updated the final commit to remove from /tmp/ and /var/ again in case a user creates extra files through custom instructions.

Closes #101 #95 