### PR TITLE
feat: revert to bash files module

### DIFF
--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -2,8 +2,6 @@
   {%- if let Some(type) = module.module_type %}
     {%- if type == "containerfile" %}
       {%- include "modules/containerfile/containerfile.j2" %}
-    {%- else if type == "files" %}
-      {%- include "modules/files/files.j2" %}
     {%- else %}
 RUN \
   --mount=type=tmpfs,target=/var \


### PR DESCRIPTION
https://github.com/blue-build/cli/issues/118#issuecomment-1992536977
as mentioned here reverting to the bash files module simplifies the build process (and allows for better usage of `ostree container commit`). It also means there are less overall layers and (ideally) a smaller image as a result. Tested locally and template generation seems to work just fine