### PR TITLE
fix: Allow docker driver to properly use cache

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          driver: docker
           install: true
 
       - name: Earthly login
@@ -119,6 +118,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_PR_EVENT_NUMBER: ${{ github.event.number }}
           COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
+          BB_BUILDKIT_CACHE_GHA: true
         run: |
           cd integration-tests/test-repo
           if [ -n "$GH_TOKEN" ] && [ -n "$COSIGN_PRIVATE_KEY" ]; then

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -219,7 +219,6 @@ impl BlueBuildCommand for BuildCommand {
 
         if self.push {
             blue_build_utils::check_command_exists("cosign")?;
-            blue_build_utils::check_command_exists("skopeo")?;
             check_cosign_files()?;
         }
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -253,6 +253,7 @@ impl BuildCommand {
         } else {
             BuildTagPushOpts::builder()
                 .image(&image_name)
+                .tags(tags.iter().map(String::as_str).collect::<Vec<_>>())
                 .push(self.push)
                 .no_retry_push(self.no_retry_push)
                 .retry_count(self.retry_count)

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -356,7 +356,7 @@ impl BuildCommand {
             _ => {
                 trace!("Nothing to indicate an image name with a registry");
                 if self.push {
-                    bail!("Need '--registry' and '--registry-path' in order to push image");
+                    bail!("Need '--registry' and '--registry-namespace' in order to push image");
                 }
                 recipe.name.trim().to_lowercase()
             }

--- a/src/commands/local.rs
+++ b/src/commands/local.rs
@@ -58,7 +58,8 @@ impl BlueBuildCommand for UpgradeCommand {
             .force(self.common.force)
             .build();
 
-        let image_name = build.generate_full_image_name(&recipe)?;
+        let image_name = recipe.name.to_lowercase().replace('/', "_");
+
         clean_local_build_dir(&image_name, false)?;
         debug!("Image name is {image_name}");
 
@@ -106,7 +107,7 @@ impl BlueBuildCommand for RebaseCommand {
             .force(self.common.force)
             .build();
 
-        let image_name = build.generate_full_image_name(&recipe)?;
+        let image_name = recipe.name.to_lowercase().replace('/', "_");
         clean_local_build_dir(&image_name, true)?;
         debug!("Image name is {image_name}");
 
@@ -158,7 +159,7 @@ fn clean_local_build_dir(image_name: &str, rebase: bool) -> Result<()> {
     trace!("clean_local_build_dir()");
 
     let local_build_path = Path::new(LOCAL_BUILD);
-    let image_file_path = local_build_path.join(image_name.trim_start_matches("oci-archive:"));
+    let image_file_path = local_build_path.join(format!("{image_name}.{ARCHIVE_SUFFIX}"));
 
     if !image_file_path.exists() && !rebase {
         bail!(

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -302,7 +302,7 @@ impl Driver<'_> {
     }
 
     fn determine_inspect_driver() -> Result<Arc<dyn InspectDriver>> {
-        trace!("Driver::determine_inspect_strategy()");
+        trace!("Driver::determine_inspect_driver()");
 
         let driver: Arc<dyn InspectDriver> = match (
             blue_build_utils::check_command_exists("skopeo"),
@@ -319,7 +319,7 @@ impl Driver<'_> {
     }
 
     fn determine_build_driver() -> Result<Arc<dyn BuildDriver>> {
-        trace!("Driver::determine_build_strategy()");
+        trace!("Driver::determine_build_driver()");
 
         let driver: Arc<dyn BuildDriver> = match (
             env::var(XDG_RUNTIME_DIR),

--- a/src/drivers/docker_driver.rs
+++ b/src/drivers/docker_driver.rs
@@ -4,14 +4,14 @@ use std::{
 };
 
 use anyhow::{bail, Result};
-use blue_build_utils::constants::{BB_BUILDKIT_CACHE_GHA, SKOPEO_IMAGE};
+use blue_build_utils::constants::{BB_BUILDKIT_CACHE_GHA, CONTAINER_FILE, SKOPEO_IMAGE};
 use log::{info, trace};
 use semver::Version;
 use serde::Deserialize;
 
 use crate::image_inspection::ImageInspection;
 
-use super::{credentials, BuildDriver, DriverVersion, InspectDriver};
+use super::{credentials, opts::BuildTagPushOpts, BuildDriver, DriverVersion, InspectDriver};
 
 #[derive(Debug, Deserialize)]
 struct DockerVerisonJsonClient {
@@ -49,33 +49,16 @@ impl DriverVersion for DockerDriver {
 impl BuildDriver for DockerDriver {
     fn build(&self, image: &str) -> Result<()> {
         trace!("docker");
-        let mut command = Command::new("docker");
-
-        // https://github.com/moby/buildkit?tab=readme-ov-file#github-actions-cache-experimental
-        if env::var(BB_BUILDKIT_CACHE_GHA).map_or_else(|_| false, |e| e == "true") {
-            trace!("buildx build --load --cache-from type=gha --cache-to type=gha");
-            command
-                .arg("buildx")
-                .arg("build")
-                .arg("--load")
-                .arg("--cache-from")
-                .arg("type=gha")
-                .arg("--cache-to")
-                .arg("type=gha");
-        } else {
-            trace!("build");
-            command.arg("build");
-        }
-
-        trace!("-t {image} -f Containerfile .");
-        command
+        let status = Command::new("docker")
+            .arg("build")
             .arg("-t")
             .arg(image)
             .arg("-f")
             .arg("Containerfile")
-            .arg(".");
+            .arg(".")
+            .status()?;
 
-        if command.status()?.success() {
+        if status.success() {
             info!("Successfully built {image}");
         } else {
             bail!("Failed to build {image}");
@@ -129,7 +112,76 @@ impl BuildDriver for DockerDriver {
 
         if !output.status.success() {
             let err_out = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to login for buildah: {err_out}");
+            bail!("Failed to login for docker: {err_out}");
+        }
+        Ok(())
+    }
+
+    fn build_tag_push(&self, opts: &BuildTagPushOpts) -> Result<()> {
+        trace!("DockerDriver::build_tag_push({opts:#?})");
+
+        let mut command = Command::new("docker");
+
+        trace!("docker buildx build -f {CONTAINER_FILE}");
+        command
+            .arg("buildx")
+            .arg("build")
+            .arg("-f")
+            .arg(CONTAINER_FILE);
+
+        // https://github.com/moby/buildkit?tab=readme-ov-file#github-actions-cache-experimental
+        if env::var(BB_BUILDKIT_CACHE_GHA).map_or_else(|_| false, |e| e == "true") {
+            trace!("--cache-from type=gha --cache-to type=gha");
+            command
+                .arg("--cache-from")
+                .arg("type=gha")
+                .arg("--cache-to")
+                .arg("type=gha");
+        }
+
+        match (opts.image.as_ref(), opts.archive_path.as_ref()) {
+            (Some(image), None) => {
+                if opts.tags.is_empty() {
+                    trace!("-t {image}");
+                    command.arg("-t").arg(image.as_ref());
+                } else {
+                    for tag in opts.tags.as_ref() {
+                        let full_image = format!("{image}:{tag}");
+
+                        trace!("-t {full_image}");
+                        command.arg("-t").arg(full_image);
+                    }
+                }
+
+                if opts.push {
+                    trace!("--push");
+                    command.arg("--push");
+                } else {
+                    trace!("--builder default");
+                    command.arg("--builder").arg("default");
+                }
+            }
+            (None, Some(archive_path)) => {
+                trace!("--output type=oci,dest={archive_path}");
+                command
+                    .arg("--output")
+                    .arg(format!("type=oci,dest={archive_path}"));
+            }
+            (Some(_), Some(_)) => bail!("Cannot use both image and archive path"),
+            (None, None) => bail!("Need either the image or archive path set"),
+        }
+
+        trace!(".");
+        command.arg(".");
+
+        if command.status()?.success() {
+            if opts.push {
+                info!("Successfully built and pushed image");
+            } else {
+                info!("Successfully built image");
+            }
+        } else {
+            bail!("Failed to build image");
         }
         Ok(())
     }

--- a/src/drivers/opts.rs
+++ b/src/drivers/opts.rs
@@ -1,0 +1,3 @@
+mod build;
+
+pub use build::*;

--- a/src/drivers/opts/build.rs
+++ b/src/drivers/opts/build.rs
@@ -2,23 +2,36 @@ use std::borrow::Cow;
 
 use typed_builder::TypedBuilder;
 
+/// Options for building, tagging, and pusing images.
 #[derive(Debug, Clone, TypedBuilder)]
 pub struct BuildTagPushOpts<'a> {
+    /// The base image name.
+    ///
+    /// NOTE: You cannot have this set with archive_path set.
     #[builder(default, setter(into, strip_option))]
     pub image: Option<Cow<'a, str>>,
 
+    /// The path to the archive file.
+    ///
+    /// NOTE: You cannot have this set with image set.
     #[builder(default, setter(into, strip_option))]
     pub archive_path: Option<Cow<'a, str>>,
 
+    /// The list of tags for the image being built.
     #[builder(default, setter(into))]
     pub tags: Cow<'a, [&'a str]>,
 
+    /// Enable pushing the image.
     #[builder(default)]
     pub push: bool,
 
+    /// Disable retry logic for pushing.
     #[builder(default)]
     pub no_retry_push: bool,
 
+    /// Number of times to retry pushing.
+    ///
+    /// Defaults to 1.
     #[builder(default = 1)]
     pub retry_count: u8,
 }

--- a/src/drivers/opts/build.rs
+++ b/src/drivers/opts/build.rs
@@ -1,0 +1,24 @@
+use std::borrow::Cow;
+
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, Clone, TypedBuilder)]
+pub struct BuildTagPushOpts<'a> {
+    #[builder(default, setter(into, strip_option))]
+    pub image: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into, strip_option))]
+    pub archive_path: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    pub tags: Cow<'a, [&'a str]>,
+
+    #[builder(default)]
+    pub push: bool,
+
+    #[builder(default)]
+    pub no_retry_push: bool,
+
+    #[builder(default = 1)]
+    pub retry_count: u8,
+}

--- a/src/drivers/podman_driver.rs
+++ b/src/drivers/podman_driver.rs
@@ -6,7 +6,7 @@ use log::{debug, info, trace};
 use semver::Version;
 use serde::Deserialize;
 
-use crate::image_inspection::ImageInspection;
+use crate::image_metadata::ImageMetadata;
 
 use super::{credentials, BuildDriver, DriverVersion, InspectDriver};
 
@@ -114,7 +114,7 @@ impl BuildDriver for PodmanDriver {
 }
 
 impl InspectDriver for PodmanDriver {
-    fn get_labels(&self, image_name: &str, tag: &str) -> Result<ImageInspection> {
+    fn get_metadata(&self, image_name: &str, tag: &str) -> Result<ImageMetadata> {
         let url = format!("docker://{image_name}:{tag}");
 
         trace!("podman run {SKOPEO_IMAGE} inspect {url}");

--- a/src/drivers/podman_driver.rs
+++ b/src/drivers/podman_driver.rs
@@ -107,7 +107,7 @@ impl BuildDriver for PodmanDriver {
 
         if !output.status.success() {
             let err_out = String::from_utf8_lossy(&output.stderr);
-            bail!("Failed to login for buildah: {err_out}");
+            bail!("Failed to login for podman: {err_out}");
         }
         Ok(())
     }

--- a/src/drivers/skopeo_driver.rs
+++ b/src/drivers/skopeo_driver.rs
@@ -3,7 +3,7 @@ use std::process::{Command, Stdio};
 use anyhow::{bail, Result};
 use log::{debug, trace};
 
-use crate::image_inspection::ImageInspection;
+use crate::image_metadata::ImageMetadata;
 
 use super::InspectDriver;
 
@@ -11,7 +11,7 @@ use super::InspectDriver;
 pub struct SkopeoDriver;
 
 impl InspectDriver for SkopeoDriver {
-    fn get_labels(&self, image_name: &str, tag: &str) -> Result<ImageInspection> {
+    fn get_metadata(&self, image_name: &str, tag: &str) -> Result<ImageMetadata> {
         let url = format!("docker://{image_name}:{tag}");
 
         trace!("skopeo inspect {url}");

--- a/src/image_metadata.rs
+++ b/src/image_metadata.rs
@@ -4,12 +4,15 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct ImageInspection {
+pub struct ImageMetadata {
     #[serde(alias = "Labels")]
-    labels: HashMap<String, Value>,
+    pub labels: HashMap<String, Value>,
+
+    #[serde(alias = "Digest")]
+    pub digest: String,
 }
 
-impl ImageInspection {
+impl ImageMetadata {
     pub fn get_version(&self) -> Option<String> {
         Some(
             self.labels

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ shadow_rs::shadow!(shadow);
 pub mod commands;
 pub mod credentials;
 pub mod drivers;
-pub mod image_inspection;
+pub mod image_metadata;


### PR DESCRIPTION
This fix involves creating a new function for the `BuildDriver` trait called `build_tag_push`. In order to get the proper logic in place to make use of `docker buildx`, I had to create a separate function that would construct the build command to include all of the tags necessary for pushing. A default implementation of `build_tag_push` will be used for `podman` and `buildah` which was originally from the build command's functions. Now that we have custom logic for docker builds, we can take advantage of using the GitHub cache features without having the `--load` arg which had a big negative effect on build times. We can now also use docker for creating local `oci-archive` tarballs for local rebasing. Making use of the `oci-archive` will require the user to create a `docker-container` builder as it is not supported on the standard `docker` builder.

https://docs.docker.com/build/exporters/oci-docker/