### PR TITLE
feat: Support `zstd` compression

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -21,7 +21,10 @@ use typed_builder::TypedBuilder;
 use crate::{
     commands::template::TemplateCommand,
     credentials,
-    drivers::{opts::BuildTagPushOpts, Driver},
+    drivers::{
+        opts::{BuildTagPushOpts, CompressionType},
+        Driver,
+    },
 };
 
 use super::BlueBuildCommand;
@@ -41,6 +44,12 @@ pub struct BuildCommand {
     #[arg(short, long)]
     #[builder(default)]
     push: bool,
+
+    /// The compression format the images
+    /// will be pushed in.
+    #[arg(short, long, default_value_t = CompressionType::Zstd)]
+    #[builder(default)]
+    compression_format: CompressionType,
 
     /// Block `bluebuild` from retrying to push the image.
     #[arg(short, long, default_value_t = true)]
@@ -207,6 +216,7 @@ impl BuildCommand {
                 .push(self.push)
                 .no_retry_push(self.no_retry_push)
                 .retry_count(self.retry_count)
+                .compression(self.compression_format)
                 .build()
         };
 

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -22,8 +22,11 @@ use uuid::Uuid;
 use crate::{credentials, image_metadata::ImageMetadata};
 
 use self::{
-    buildah_driver::BuildahDriver, docker_driver::DockerDriver, opts::BuildTagPushOpts,
-    podman_driver::PodmanDriver, skopeo_driver::SkopeoDriver,
+    buildah_driver::BuildahDriver,
+    docker_driver::DockerDriver,
+    opts::{BuildTagPushOpts, CompressionType},
+    podman_driver::PodmanDriver,
+    skopeo_driver::SkopeoDriver,
 };
 
 mod buildah_driver;
@@ -117,7 +120,7 @@ pub trait BuildDriver: Sync + Send {
     ///
     /// # Errors
     /// Will error if the push fails.
-    fn push(&self, image: &str) -> Result<()>;
+    fn push(&self, image: &str, compression: CompressionType) -> Result<()>;
 
     /// Runs the login logic for the strategy.
     ///
@@ -173,7 +176,7 @@ pub trait BuildDriver: Sync + Send {
 
                         debug!("Pushing image {tag_image}");
 
-                        self.push(&tag_image)
+                        self.push(&tag_image, opts.compression)
                     })?;
                 }
             }

--- a/src/drivers/buildah_driver.rs
+++ b/src/drivers/buildah_driver.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::credentials;
 
-use super::{BuildDriver, DriverVersion};
+use super::{opts::CompressionType, BuildDriver, DriverVersion};
 
 #[derive(Debug, Deserialize)]
 struct BuildahVersionJson {
@@ -68,9 +68,13 @@ impl BuildDriver for BuildahDriver {
         Ok(())
     }
 
-    fn push(&self, image: &str) -> Result<()> {
+    fn push(&self, image: &str, compression: CompressionType) -> Result<()> {
         trace!("buildah push {image}");
-        let status = Command::new("buildah").arg("push").arg(image).status()?;
+        let status = Command::new("buildah")
+            .arg("push")
+            .arg(format!("--compression-format={compression}"))
+            .arg(image)
+            .status()?;
 
         if status.success() {
             info!("Successfully pushed {image}!");

--- a/src/drivers/docker_driver.rs
+++ b/src/drivers/docker_driver.rs
@@ -11,7 +11,11 @@ use serde::Deserialize;
 
 use crate::image_metadata::ImageMetadata;
 
-use super::{credentials, opts::BuildTagPushOpts, BuildDriver, DriverVersion, InspectDriver};
+use super::{
+    credentials,
+    opts::{BuildTagPushOpts, CompressionType},
+    BuildDriver, DriverVersion, InspectDriver,
+};
 
 #[derive(Debug, Deserialize)]
 struct DockerVerisonJsonClient {
@@ -88,7 +92,7 @@ impl BuildDriver for DockerDriver {
         Ok(())
     }
 
-    fn push(&self, image: &str) -> Result<()> {
+    fn push(&self, image: &str, _: CompressionType) -> Result<()> {
         trace!("DockerDriver::push({image})");
 
         trace!("docker push {image}");
@@ -162,8 +166,11 @@ impl BuildDriver for DockerDriver {
                 }
 
                 if opts.push {
-                    trace!("--push");
-                    command.arg("--push");
+                    trace!("--output type=image,name={image},push=true,compression={},oci-mediatypes=true", opts.compression);
+                    command.arg("--output").arg(format!(
+                        "type=image,name={image},push=true,compression={},oci-mediatypes=true",
+                        opts.compression
+                    ));
                 } else {
                     trace!("--builder default");
                     command.arg("--builder").arg("default");

--- a/src/drivers/opts/build.rs
+++ b/src/drivers/opts/build.rs
@@ -2,6 +2,22 @@ use std::borrow::Cow;
 
 use typed_builder::TypedBuilder;
 
+#[derive(Debug, Copy, Clone, Default)]
+pub enum CompressionType {
+    #[default]
+    Zstd,
+    Gzip,
+}
+
+impl std::fmt::Display for CompressionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Zstd => "zstd",
+            Self::Gzip => "gzip",
+        })
+    }
+}
+
 /// Options for building, tagging, and pusing images.
 #[derive(Debug, Clone, TypedBuilder)]
 pub struct BuildTagPushOpts<'a> {
@@ -34,4 +50,7 @@ pub struct BuildTagPushOpts<'a> {
     /// Defaults to 1.
     #[builder(default = 1)]
     pub retry_count: u8,
+
+    #[builder(default)]
+    pub compression: CompressionType,
 }

--- a/src/drivers/opts/build.rs
+++ b/src/drivers/opts/build.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
+use clap::ValueEnum;
 use typed_builder::TypedBuilder;
 
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, ValueEnum)]
 pub enum CompressionType {
     #[default]
     Zstd,

--- a/src/drivers/podman_driver.rs
+++ b/src/drivers/podman_driver.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::image_metadata::ImageMetadata;
 
-use super::{credentials, BuildDriver, DriverVersion, InspectDriver};
+use super::{credentials, opts::CompressionType, BuildDriver, DriverVersion, InspectDriver};
 
 #[derive(Debug, Deserialize)]
 struct PodmanVersionJsonClient {
@@ -79,9 +79,13 @@ impl BuildDriver for PodmanDriver {
         Ok(())
     }
 
-    fn push(&self, image: &str) -> Result<()> {
+    fn push(&self, image: &str, compression: CompressionType) -> Result<()> {
         trace!("podman push {image}");
-        let status = Command::new("podman").arg("push").arg(image).status()?;
+        let status = Command::new("podman")
+            .arg("push")
+            .arg(format!("--compression-format={compression}"))
+            .arg(image)
+            .status()?;
 
         if status.success() {
             info!("Successfully pushed {image}!");


### PR DESCRIPTION
All supported versions of podman, buildah, and docker support the zstd compression format. This format should allow users to pull less data when updating their computers.