### PR TITLE
chore: add MODULE_DIRECTORY env var

### DIFF
--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -14,6 +14,7 @@ ARG RECIPE={{ recipe_path.display() }}
 ARG IMAGE_REGISTRY={{ registry }}
 
 ARG CONFIG_DIRECTORY="/tmp/config"
+ARG MODULE_DIRECTORY="/tmp/modules"
 ARG IMAGE_NAME="{{ recipe.name }}"
 ARG BASE_IMAGE="{{ recipe.base_image }}"
 


### PR DESCRIPTION
This exists in the legacy template:
https://github.com/blue-build/legacy-template/blob/489ebea77b79bd722679352bf8c75f185562e3b6/build.sh#L13C1-L13C39

And is also used in many modules, though with `MODULE_DIRECTORY="${MODULE_DIRECTORY:-"/tmp/modules"}"` to not break things.

And is documented on the website, because I assumed it existed: https://blue-build.org/reference/module/#module_directory

I know this probably won't change much, but it's still useful for the scripts.