### PR TITLE
fix: Sign all images in manifest

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -383,6 +383,7 @@ fn sign_images(image_name: &str, tag: Option<&str>) -> Result<()> {
 
             if Command::new("cosign")
                 .arg("sign")
+                .arg("--recursive")
                 .arg(&image_name_digest)
                 .status()?
                 .success()
@@ -421,6 +422,7 @@ fn sign_images(image_name: &str, tag: Option<&str>) -> Result<()> {
             trace!("cosign sign {image_name_digest}");
             if Command::new("cosign")
                 .arg("sign")
+                .arg("--recursive")
                 .arg(&image_name_digest)
                 .status()?
                 .success()
@@ -458,6 +460,7 @@ fn sign_priv_public_pair(image_digest: &str, image_name_tag: &str) -> Result<()>
     if Command::new("cosign")
         .arg("sign")
         .arg("--key=env://COSIGN_PRIVATE_KEY")
+        .arg("--recursive")
         .arg(image_digest)
         .status()?
         .success()


### PR DESCRIPTION
Resolves #147

`cosign sign` only signs the provided digest by default. If that digest is a manifest which is currently the default for images built with Docker due to https://docs.docker.com/build/attestations/attestation-storage/, we also want to sign each image with `--recursive` so that they can be pulled by any container managers which enforce that (e.g. podman).

Refer to https://github.com/sigstore/cosign/blob/main/doc/cosign_sign.md for more details.