### PR TITLE
feat: Add driver selection args

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,13 @@
 use log::error;
 
-use clap::{command, crate_authors, Parser, Subcommand};
+use clap::{command, crate_authors, Args, Parser, Subcommand};
 use clap_verbosity_flag::{InfoLevel, Verbosity};
+use typed_builder::TypedBuilder;
 
-use crate::shadow;
+use crate::{
+    drivers::types::{BuildDriverType, InspectDriverType},
+    shadow,
+};
 
 pub mod bug_report;
 pub mod build;
@@ -91,4 +95,19 @@ pub enum CommandArgs {
 
     /// Generate shell completions for your shell to stdout
     Completions(completions::CompletionsCommand),
+}
+
+#[derive(Default, Clone, Copy, Debug, TypedBuilder, Args)]
+pub struct DriverArgs {
+    /// Select which driver to use to build
+    /// your image.
+    #[builder(default)]
+    #[arg(long)]
+    build_driver: Option<BuildDriverType>,
+
+    /// Select which driver to use to inspect
+    /// images.
+    #[builder(default)]
+    #[arg(long)]
+    inspect_driver: Option<InspectDriverType>,
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -102,12 +102,12 @@ pub struct DriverArgs {
     /// Select which driver to use to build
     /// your image.
     #[builder(default)]
-    #[arg(long)]
+    #[arg(short = 'B', long)]
     build_driver: Option<BuildDriverType>,
 
     /// Select which driver to use to inspect
     /// images.
     #[builder(default)]
-    #[arg(long)]
+    #[arg(short = 'I', long)]
     inspect_driver: Option<InspectDriverType>,
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -27,7 +27,7 @@ use crate::{
     },
 };
 
-use super::BlueBuildCommand;
+use super::{BlueBuildCommand, DriverArgs};
 
 #[derive(Debug, Clone, Args, TypedBuilder)]
 pub struct BuildCommand {
@@ -99,6 +99,10 @@ pub struct BuildCommand {
     #[arg(short = 'P', long)]
     #[builder(default, setter(into, strip_option))]
     password: Option<String>,
+
+    #[clap(flatten)]
+    #[builder(default)]
+    drivers: DriverArgs,
 }
 
 impl BlueBuildCommand for BuildCommand {
@@ -110,6 +114,8 @@ impl BlueBuildCommand for BuildCommand {
             .username(self.username.as_ref())
             .password(self.password.as_ref())
             .registry(self.registry.as_ref())
+            .build_driver(self.drivers.build_driver)
+            .inspect_driver(self.drivers.inspect_driver)
             .build()
             .init()?;
 

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -12,7 +12,7 @@ use typed_builder::TypedBuilder;
 
 use crate::drivers::Driver;
 
-use super::BlueBuildCommand;
+use super::{BlueBuildCommand, DriverArgs};
 
 #[derive(Debug, Clone, Args, TypedBuilder)]
 pub struct TemplateCommand {
@@ -41,6 +41,10 @@ pub struct TemplateCommand {
     #[arg(long)]
     #[builder(default, setter(into, strip_option))]
     registry_namespace: Option<String>,
+
+    #[clap(flatten)]
+    #[builder(default)]
+    drivers: DriverArgs,
 }
 
 impl BlueBuildCommand for TemplateCommand {
@@ -52,6 +56,12 @@ impl BlueBuildCommand for TemplateCommand {
                 .unwrap_or_else(|| PathBuf::from(RECIPE_PATH))
                 .display()
         );
+
+        Driver::builder()
+            .build_driver(self.drivers.build_driver)
+            .inspect_driver(self.drivers.inspect_driver)
+            .build()
+            .init()?;
 
         self.template_file()
     }

--- a/src/drivers/types.rs
+++ b/src/drivers/types.rs
@@ -1,0 +1,15 @@
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum InspectDriverType {
+    Skopeo,
+    Podman,
+    Docker,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum BuildDriverType {
+    Buildah,
+    Podman,
+    Docker,
+}


### PR DESCRIPTION
There are 2 new args available that allow the user to specify which program to use for building and inspecting images. If the user doesn't provide an argument, the tool will determine which program to use like it has been.

Help text:

```
Build an image from a recipe

Usage: bluebuild build [OPTIONS] [RECIPE]

Arguments:
  [RECIPE]
          The recipe file to build an image

Options:
  -p, --push
          Push the image with all the tags.

          Requires `--registry`, `--username`, and `--password` if not building in CI.

  -c, --compression-format <COMPRESSION_FORMAT>
          The compression format the images will be pushed in

          [default: gzip]
          [possible values: gzip, zstd]

  -n, --no-retry-push
          Block `bluebuild` from retrying to push the image

      --retry-count <RETRY_COUNT>
          The number of times to retry pushing the image

          [default: 1]

  -f, --force
          Allow `bluebuild` to overwrite an existing Containerfile without confirmation.

          This is not needed if the Containerfile is in .gitignore or has already been built by `bluebuild`.

  -a, --archive <ARCHIVE>
          Archives the built image into a tarfile in the specified directory

      --registry <REGISTRY>
          The registry's domain name

  -v, --verbose...
          Increase logging verbosity

  -q, --quiet...
          Decrease logging verbosity

      --registry-namespace <REGISTRY_NAMESPACE>
          The url path to your base project images

          [aliases: registry-path]

  -U, --username <USERNAME>
          The username to login to the container registry

  -P, --password <PASSWORD>
          The password to login to the container registry

  -B, --build-driver <BUILD_DRIVER>
          Select which driver to use to build your image

          [possible values: buildah, podman, docker]

  -I, --inspect-driver <INSPECT_DRIVER>
          Select which driver to use to inspect images

          [possible values: skopeo, podman, docker]

  -h, --help
          Print help (see a summary with '-h')
```