### PR TITLE
chore: Cleanup images and use hash for exports tag

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -50,6 +50,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Run build
+        id: build
         run: |
           if [ -n "${{ github.token }}" ]; then
             earthly --ci --push +exports-script

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    if: needs.build.has_exports == "true"
+    if: needs.build.has_exports == 'true'
 
     steps:
       - name: Maximize build space
@@ -101,7 +101,7 @@ jobs:
       id-token: write
     needs:
       - build
-    if: needs.build.has_exports == "true"
+    if: needs.build.has_exports == 'true'
 
     steps:
       - name: Maximize build space

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -25,8 +25,6 @@ jobs:
         if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.4
 
       - name: Earthly login
         env:
@@ -75,8 +73,6 @@ jobs:
         if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.4
 
       - name: Earthly login
         env:
@@ -112,8 +108,6 @@ jobs:
 
       - uses: sigstore/cosign-installer@v3.3.0
       - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -129,7 +129,6 @@ jobs:
 
       - name: Install bluebuild
         run: |
-          earthly +exports-script
           earthly -a +install/bluebuild --BUILD_TARGET=x86_64-unknown-linux-musl /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           if [ -n "${{ github.token }}" ]; then
             earthly --ci --push +exports-script
+            echo "has_exports=true" >> "$GITHUB_OUTPUT"
           fi
           earthly --ci +build
 
@@ -61,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    if: needs.build.has_exports == "true"
 
     steps:
       - name: Maximize build space
@@ -78,7 +80,7 @@ jobs:
           EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
         if: env.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 
@@ -88,7 +90,6 @@ jobs:
           ref: ${{ github.event.pull_request.ref }}
 
       - name: Run integration tests
-        if: github.repository == 'blue-build/cli'
         run: earthly --ci -P ./integration-tests+all
 
   docker-build:
@@ -100,6 +101,7 @@ jobs:
       id-token: write
     needs:
       - build
+    if: needs.build.has_exports == "true"
 
     steps:
       - name: Maximize build space
@@ -143,8 +145,4 @@ jobs:
           cd integration-tests/test-repo
           bluebuild template -vv | tee Containerfile
           grep -q 'ARG IMAGE_REGISTRY=ghcr.io/blue-build' Containerfile || exit 1
-          if [ -n "$GH_TOKEN" ] && [ -n "$COSIGN_PRIVATE_KEY" ]; then
-            bluebuild build --push -vv
-          else
-            bluebuild build -vv
-          fi
+          bluebuild build --push -vv

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -96,9 +96,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    needs:
-      - build
-
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Earthly login
         if: github.secrets.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Install bluebuild
         run: |
-          earthly -a +blue-build-cli-alpine/usr/bin/bluebuild /usr/local/bin/bluebuild
+          earthly -a +installer/bluebuild /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -41,21 +41,21 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: secrets.GITHUB_TOKEN != null
+        if: github.secrets.GITHUB_TOKEN != null
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.secrets.GITHUB_TOKEN }}
 
       - name: Run build
         run: |
-          if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
+          if [ -n "${{ github.secrets.GITHUB_TOKEN }}" ]; then
             earthly --ci --push +exports-script
           fi
           earthly --ci +build
 
   integration-tests:
-    if: secrets.GITHUB_TOKEN != null
+    if: github.secrets.GITHUB_TOKEN != null
     permissions:
       packages: write
     timeout-minutes: 60

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
-          earthly sat s blue-build-integration-tests
+          earthly sat s blue-build-pr
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
-        if: github.secrets.EARTHLY_SAT_TOKEN == null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
@@ -53,7 +55,6 @@ jobs:
           earthly --ci +build
 
   integration-tests:
-    if: github.token != null
     permissions:
       packages: write
     timeout-minutes: 60
@@ -64,14 +65,18 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
-        if: github.secrets.EARTHLY_SAT_TOKEN == null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.4
 
       - name: Earthly login
-        if: github.secrets.EARTHLY_SAT_TOKEN != null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
         run: |
           earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
@@ -87,7 +92,6 @@ jobs:
         run: earthly --ci -P ./integration-tests+all
 
   docker-build:
-    if: github.token != null
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install bluebuild
         run: |
-          earthly -a +install/bluebuild --BUILD_TARGET=x86_64-unknown-linux-musl /usr/local/bin/bluebuild
+          earthly -a +blue-build-cli-alpine/usr/bin/bluebuild /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -39,10 +39,23 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.ref }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        if: secrets.GITHUB_TOKEN != null
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run build
-        run: earthly --ci +build
+        run: |
+          if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
+            earthly --ci --push +exports-script
+          fi
+          earthly --ci +build
 
   integration-tests:
+    if: secrets.GITHUB_TOKEN != null
     permissions:
       packages: write
     timeout-minutes: 60

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    outputs:
+      export: ${{ steps.build.outputs.export }}
 
     steps:
       - name: Maximize build space
@@ -51,7 +53,7 @@ jobs:
         run: |
           if [ -n "${{ github.token }}" ]; then
             earthly --ci --push +exports-script
-            echo "has_exports=true" >> "$GITHUB_OUTPUT"
+            echo "export=true" >> "$GITHUB_OUTPUT"
           fi
           earthly --ci +build
 
@@ -62,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    if: needs.build.has_exports == 'true'
+    if: needs.build.outputs.export == 'true'
 
     steps:
       - name: Maximize build space
@@ -101,7 +103,7 @@ jobs:
       id-token: write
     needs:
       - build
-    if: needs.build.has_exports == 'true'
+    if: needs.build.outputs.export == 'true'
 
     steps:
       - name: Maximize build space

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Install bluebuild
         run: |
+          earthly +exports-script
           earthly -a +install/bluebuild --BUILD_TARGET=x86_64-unknown-linux-musl /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -118,7 +118,9 @@ jobs:
           install: true
 
       - name: Earthly login
-        if: github.secrets.EARTHLY_SAT_TOKEN != null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -90,12 +90,16 @@ jobs:
         run: earthly --ci -P ./integration-tests+all
 
   docker-build:
+    if: github.secrets.GITHUB_TOKEN != null
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
+    needs:
+      - build
+
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,9 +18,7 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN == null
+        if: github.secrets.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
@@ -41,21 +39,21 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: github.secrets.GITHUB_TOKEN != null
+        if: github.token != null
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
 
       - name: Run build
         run: |
-          if [ -n "${{ github.secrets.GITHUB_TOKEN }}" ]; then
+          if [ -n "${{ github.token }}" ]; then
             earthly --ci --push +exports-script
           fi
           earthly --ci +build
 
   integration-tests:
-    if: github.secrets.GITHUB_TOKEN != null
+    if: github.token != null
     permissions:
       packages: write
     timeout-minutes: 60
@@ -66,17 +64,16 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
+        if: github.secrets.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.4
 
       - name: Earthly login
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN != null
+        if: github.secrets.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 
@@ -90,7 +87,7 @@ jobs:
         run: earthly --ci -P ./integration-tests+all
 
   docker-build:
-    if: github.secrets.GITHUB_TOKEN != null
+    if: github.token != null
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
@@ -115,11 +112,9 @@ jobs:
           install: true
 
       - name: Earthly login
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN != null
+        if: github.secrets.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,6 @@ jobs:
         if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.4
 
       - name: Earthly login
         env:
@@ -77,8 +75,6 @@ jobs:
         if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.4
 
       - name: Earthly login
         env:
@@ -115,8 +111,6 @@ jobs:
 
       - uses: sigstore/cosign-installer@v3.3.0
       - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,9 +97,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-    needs:
-      - build
-
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
@@ -129,6 +126,7 @@ jobs:
 
       - name: Install bluebuild
         run: |
+          earthly +exports-script
           earthly -a +install/bluebuild --BUILD_TARGET=x86_64-unknown-linux-musl /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install bluebuild
         run: |
-          earthly -a +install/bluebuild --BUILD_TARGET=x86_64-unknown-linux-musl /usr/local/bin/bluebuild
+          earthly -a +blue-build-cli-alpine/usr/bin/bluebuild /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,9 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    needs:
+      - build
+
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
@@ -126,7 +129,6 @@ jobs:
 
       - name: Install bluebuild
         run: |
-          earthly +exports-script
           earthly -a +install/bluebuild --BUILD_TARGET=x86_64-unknown-linux-musl /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,20 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
-        if: github.secrets.EARTHLY_SAT_TOKEN == null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.4
 
       - name: Earthly login
-        if: github.secrets.EARTHLY_SAT_TOKEN != null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-main
 
@@ -63,16 +67,20 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
-        if: github.secrets.EARTHLY_SAT_TOKEN == null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.4
 
       - name: Earthly login
-        if: github.secrets.EARTHLY_SAT_TOKEN != null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 
@@ -110,9 +118,11 @@ jobs:
           install: true
 
       - name: Earthly login
-        if: github.secrets.EARTHLY_SAT_TOKEN != null
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 
@@ -131,7 +141,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_PR_EVENT_NUMBER: ${{ github.event.number }}
-          COSIGN_PRIVATE_KEY: ${{ github.secrets.TEST_SIGNING_SECRET }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
           BB_BUILDKIT_CACHE_GHA: true
         run: |
           cd integration-tests/test-repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,20 +23,16 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN == null
+        if: github.secrets.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.4
 
       - name: Earthly login
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN != null
+        if: github.secrets.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-main
 
@@ -67,17 +63,16 @@ jobs:
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
+        if: github.secrets.EARTHLY_SAT_TOKEN == null
 
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.4
 
       - name: Earthly login
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN != null
+        if: github.secrets.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 
@@ -115,11 +110,9 @@ jobs:
           install: true
 
       - name: Earthly login
-        env:
-          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
-        if: env.EARTHLY_SAT_TOKEN != null
+        if: github.secrets.EARTHLY_SAT_TOKEN != null
         run: |
-          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly account login --token ${{ github.secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
           earthly sat s blue-build-integration-tests
 
@@ -138,7 +131,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_PR_EVENT_NUMBER: ${{ github.event.number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
+          COSIGN_PRIVATE_KEY: ${{ github.secrets.TEST_SIGNING_SECRET }}
           BB_BUILDKIT_CACHE_GHA: true
         run: |
           cd integration-tests/test-repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,16 @@ jobs:
         if: github.repository == 'blue-build/cli'
         run: earthly --push --ci +build
 
+      - name: Run build fork
+        if: github.repository != 'blue-build/cli'
+        run: earthly --ci +build
+
   integration-tests:
     permissions:
       packages: write
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    if: github.repository == 'blue-build/cli'
     needs:
       - build
 
@@ -100,6 +105,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    if: github.repository == 'blue-build/cli'
     needs:
       - build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Install bluebuild
         run: |
-          earthly -a +blue-build-cli-alpine/usr/bin/bluebuild /usr/local/bin/bluebuild
+          earthly -a +installer/bluebuild /usr/local/bin/bluebuild
 
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
-          earthly sat s blue-build-integration-tests
+          earthly sat s blue-build-main
 
       - uses: actions/checkout@v4
         with:

--- a/Earthfile
+++ b/Earthfile
@@ -42,8 +42,8 @@ exports-script:
 	COPY exports.sh /
 	RUN chmod +x exports.sh
 
-	ARG EARTHLY_GIT_SHORT_HASH
-	SAVE IMAGE --push $IMAGE:$EARTHLY_GIT_SHORT_HASH-exports
+	ARG EARTHLY_GIT_HASH
+	SAVE IMAGE --push $IMAGE:$EARTHLY_GIT_HASH-exports
 
 common:
 	FROM ghcr.io/blue-build/earthly-lib/cargo-builder
@@ -114,11 +114,10 @@ blue-build-cli-alpine:
 	ENTRYPOINT ["bluebuild"]
 
 	ARG TAG
-	ARG LATEST=false
-
 	IF [ -n "$TAG" ]
 		SAVE IMAGE --push $IMAGE:$TAG-alpine
 
+		ARG LATEST=false
 		IF [ "$LATEST" = "true" ]
 			SAVE IMAGE --push $IMAGE:latest-alpine
 		END
@@ -136,11 +135,10 @@ installer:
 	CMD ["cat", "/install.sh"]
 
 	ARG TAG
-	ARG LATEST=false
-
 	IF [ -n "$TAG" ]
 		SAVE IMAGE --push $IMAGE:$TAG-installer
 
+		ARG LATEST=false
 		IF [ "$LATEST" = "true" ]
 			SAVE IMAGE --push $IMAGE:latest-installer
 		END

--- a/Earthfile
+++ b/Earthfile
@@ -146,6 +146,7 @@ installer:
 		ARG EARTHLY_GIT_BRANCH
 		SAVE IMAGE --push $IMAGE:$EARTHLY_GIT_BRANCH-installer
 	END
+	SAVE ARTIFACT /out/bluebuild
 
 cosign:
 	FROM gcr.io/projectsigstore/cosign

--- a/Earthfile
+++ b/Earthfile
@@ -42,13 +42,8 @@ exports-script:
 	COPY exports.sh /
 	RUN chmod +x exports.sh
 
-	ARG TAG
-	IF [ -n "$TAG" ]
-		SAVE IMAGE --push $IMAGE:$TAG-exports
-	ELSE
-		ARG EARTHLY_GIT_BRANCH
-		SAVE IMAGE --push $IMAGE:$EARTHLY_GIT_BRANCH-exports
-	END
+	ARG EARTHLY_GIT_SHORT_HASH
+	SAVE IMAGE --push $IMAGE:$EARTHLY_GIT_SHORT_HASH-exports
 
 common:
 	FROM ghcr.io/blue-build/earthly-lib/cargo-builder

--- a/Earthfile
+++ b/Earthfile
@@ -54,7 +54,7 @@ common:
 	COPY --keep-ts *.md /app
 	COPY --keep-ts LICENSE /app
 	COPY --keep-ts build.rs /app
-	COPY --dir .git/ /app
+	COPY --keep-ts --dir .git/ /app
 	RUN touch build.rs
 
 	DO cargo+INIT

--- a/Earthfile
+++ b/Earthfile
@@ -55,6 +55,7 @@ common:
 	COPY --keep-ts LICENSE /app
 	COPY --keep-ts build.rs /app
 	COPY --dir .git/ /app
+	RUN touch build.rs
 
 	DO cargo+INIT
 

--- a/build.rs
+++ b/build.rs
@@ -7,12 +7,7 @@ fn main() -> SdResult<()> {
     shadow_rs::new_hook(hook)
 }
 
-fn hook(file: &File) -> SdResult<()> {
-    append_write_const(file)?;
-    Ok(())
-}
-
-fn append_write_const(mut file: &File) -> SdResult<()> {
+fn hook(mut file: &File) -> SdResult<()> {
     let hash = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()
@@ -23,11 +18,15 @@ fn append_write_const(mut file: &File) -> SdResult<()> {
         })
         .unwrap_or(None);
 
-    let short_hash = hash.as_ref().map(|hash| {
-        let mut hash = hash.clone();
-        hash.truncate(8);
-        hash
-    });
+    let short_hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .map(|x| {
+            String::from_utf8(x.stdout)
+                .ok()
+                .map(|x| x.trim().to_string())
+        })
+        .unwrap_or(None);
 
     let hook_const: &str = &format!(
         "{}\n{}",

--- a/build.rs
+++ b/build.rs
@@ -23,15 +23,11 @@ fn append_write_const(mut file: &File) -> SdResult<()> {
         })
         .unwrap_or(None);
 
-    let short_hash = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .map(|x| {
-            String::from_utf8(x.stdout)
-                .ok()
-                .map(|x| x.trim().to_string())
-        })
-        .unwrap_or(None);
+    let short_hash = hash.as_ref().map(|hash| {
+        let mut hash = hash.clone();
+        hash.truncate(8);
+        hash
+    });
 
     let hook_const: &str = &format!(
         "{}\n{}",

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -86,7 +86,7 @@ impl TemplateCommand {
             .recipe(&recipe_de)
             .recipe_path(recipe_path.as_path())
             .registry(self.get_registry())
-            .exports_tag(shadow::BB_COMMIT_HASH_SHORT)
+            .exports_tag(shadow::BB_COMMIT_HASH)
             .build();
 
         let output_str = template.render()?;

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -86,7 +86,7 @@ impl TemplateCommand {
             .recipe(&recipe_de)
             .recipe_path(recipe_path.as_path())
             .registry(self.get_registry())
-            .exports_tag(shadow::TAG)
+            .exports_tag(shadow::BB_COMMIT_HASH_SHORT)
             .build();
 
         let output_str = template.render()?;

--- a/src/commands/template.rs
+++ b/src/commands/template.rs
@@ -10,7 +10,7 @@ use clap::Args;
 use log::{debug, info, trace};
 use typed_builder::TypedBuilder;
 
-use crate::drivers::Driver;
+use crate::{drivers::Driver, shadow};
 
 use super::{BlueBuildCommand, DriverArgs};
 
@@ -86,6 +86,7 @@ impl TemplateCommand {
             .recipe(&recipe_de)
             .recipe_path(recipe_path.as_path())
             .registry(self.get_registry())
+            .exports_tag(shadow::TAG)
             .build();
 
         let output_str = template.render()?;

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -27,6 +27,9 @@ pub struct ContainerFileTemplate<'a> {
 
     #[builder(setter(into))]
     registry: Cow<'a, str>,
+
+    #[builder(setter(into))]
+    exports_tag: Cow<'a, str>,
 }
 
 #[derive(Debug, Clone, Template, TypedBuilder)]

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -27,7 +27,7 @@ RUN \
       {%- if type == "akmods" %}
   --mount=type=bind,from=stage-akmods-{{ module.generate_akmods_info(os_version).stage_name }},src=/rpms,dst=/tmp/rpms,rw \
       {%- endif %}
-  --mount=type=bind,from=ghcr.io/blue-build/cli:exports,src=/exports.sh,dst=/tmp/exports.sh \
+  --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-exports,src=/exports.sh,dst=/tmp/exports.sh \
   --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
   echo "========== Start {{ type|capitalize }} module ==========" \
   && chmod +x /tmp/modules/{{ type }}/{{ type }}.sh \


### PR DESCRIPTION
I noticed that making changes to the exports script before a release could cause modules to not build properly if breaking changes got pushed out. To prevent this, I'm making it so that the hash of the commit is put in the tag for the exports script image and that the CLI tool will use that hash when building the `Containerfile`.