### PR TITLE
fix: Error if any module fails to deserialize

### DIFF
--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -140,7 +140,7 @@ impl<'a> Recipe<'a> {
         let mut recipe = serde_yaml::from_str::<Recipe>(&file)
             .map_err(blue_build_utils::serde_yaml_err(&file))?;
 
-        recipe.modules_ext.modules = Module::get_modules(&recipe.modules_ext.modules).into();
+        recipe.modules_ext.modules = Module::get_modules(&recipe.modules_ext.modules)?.into();
 
         Ok(recipe)
     }


### PR DESCRIPTION
Previous implementation wasn't taking into account the modules failing to be read properly and were just being ignored. This changes that to error out if any `from-file:` usage doesn't deserialize properly.