### PR TITLE
chore: Update akmods module to account for upstream changes

### DIFF
--- a/integration-tests/test-repo/recipes/akmods.yml
+++ b/integration-tests/test-repo/recipes/akmods.yml
@@ -4,7 +4,7 @@ modules:
   # Tests installing rpms from a combo image stage
   - type: akmods
     base: surface
-    nvidia-version: 545
+    nvidia: true
     # install:
     #   - nvidia
     #   - openrazer
@@ -15,7 +15,7 @@ modules:
 
   # Tests pulling image for main nvidia
   - type: akmods
-    nvidia-version: 545
+    nvidia: true
 
   # Test pulling image for base asus
   - type: akmods


### PR DESCRIPTION
This change updates the akmods module to pull the new nvidia images. The new property will be a boolean with property name of `nvidia`. If a user continues to use the old `nvidia-version` property, a warning will be printed telling them to switch to the new property. The old images will still be allowed to be used to support backwards compatibility.