### PR TITLE
feat: Add alternate tags for user images

### DIFF
--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -1,6 +1,9 @@
 name: cli/test
 description: This is my personal OS image.
 base-image: ghcr.io/ublue-os/silverblue-main
+alt-tags:
+  - gts
+  - stable
 image-version: 39
 modules:
   - from-file: akmods.yml


### PR DESCRIPTION
This adds the ability for the user to add alternate tags to their images. These are designed to replace the `latest` and timestamp (e.g. `20240429`) tags.