### PR TITLE
feat: Stages

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -152,3 +152,63 @@ jobs:
           bluebuild template -vv | tee Containerfile
           grep -q 'ARG IMAGE_REGISTRY=ghcr.io/blue-build' Containerfile || exit 1
           bluebuild build --push -vv
+
+  podman-build:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    needs:
+      - build
+    if: needs.build.outputs.push == 'true'
+
+    steps:
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
+
+      - uses: sigstore/cosign-installer@v3.3.0
+      - uses: earthly/actions-setup@v1
+
+      - name: Setup Podman
+        shell: bash
+        run: |
+          # from https://askubuntu.com/questions/1414446/whats-the-recommended-way-of-installing-podman-4-in-ubuntu-22-04
+          ubuntu_version='22.04'
+          key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
+          sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
+          echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
+          curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Earthly login
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
+        run: |
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly org s blue-build
+          earthly sat s pr
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Install bluebuild
+        run: |
+          earthly -a +installer/bluebuild /usr/local/bin/bluebuild
+
+      - name: Run Build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_PR_EVENT_NUMBER: ${{ github.event.number }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
+        run: |
+          cd integration-tests/test-repo
+          bluebuild template -vv | tee Containerfile
+          grep -q 'ARG IMAGE_REGISTRY=ghcr.io/blue-build' Containerfile || exit 1
+          bluebuild build -B podman --push -vv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,3 +148,63 @@ jobs:
           bluebuild template -vv | tee Containerfile
           grep -q 'ARG IMAGE_REGISTRY=ghcr.io/blue-build' Containerfile || exit 1
           bluebuild build --push -vv
+
+  podman-build:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    needs:
+      - build
+    if: needs.build.outputs.push == 'true'
+
+    steps:
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
+
+      - uses: sigstore/cosign-installer@v3.3.0
+      - uses: earthly/actions-setup@v1
+
+      - name: Setup Podman
+        shell: bash
+        run: |
+          # from https://askubuntu.com/questions/1414446/whats-the-recommended-way-of-installing-podman-4-in-ubuntu-22-04
+          ubuntu_version='22.04'
+          key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
+          sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
+          echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
+          curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Earthly login
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
+        run: |
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly org s blue-build
+          earthly sat s pr
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Install bluebuild
+        run: |
+          earthly -a +installer/bluebuild /usr/local/bin/bluebuild
+
+      - name: Run Build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_PR_EVENT_NUMBER: ${{ github.event.number }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
+        run: |
+          cd integration-tests/test-repo
+          bluebuild template -vv | tee Containerfile
+          grep -q 'ARG IMAGE_REGISTRY=ghcr.io/blue-build' Containerfile || exit 1
+          bluebuild build -B podman --push -vv

--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo fmt --check && cargo test && cargo clippy -- -D warnings"
+pre-commit = "cargo fmt --check && cargo test --all-features && cargo clippy --all-features -- -D warnings"
 
 [logging]
 verbose = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "anyhow",
  "blue-build-utils",
  "chrono",
+ "colored",
  "indexmap 2.2.3",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,8 @@ uuid.workspace = true
 
 [features]
 default = []
+stages = ["blue-build-recipe/stages"]
+copy = ["blue-build-recipe/copy"]
 
 [dev-dependencies]
 rusty-hook = "0.11.2"

--- a/integration-tests/Earthfile
+++ b/integration-tests/Earthfile
@@ -79,10 +79,16 @@ secureblue-base:
 	DO +GEN_KEYPAIR
 
 legacy-base:
-	FROM +test-base
+	FROM ../+blue-build-cli-alpine
+	ENV BB_TEST_LOCAL_IMAGE=/etc/bluebuild/cli_test.tar.gz
+	ENV CLICOLOR_FORCE=1
 
-	RUN rm -fr /test
+	COPY ./mock-scripts/ /usr/bin/
+
+	WORKDIR /test
 	COPY ./legacy-test-repo /test
+
+	DO ../+INSTALL --OUT_DIR="/usr/bin/" --BUILD_TARGET="x86_64-unknown-linux-musl" --TAGGED="true"
 
 	DO +GEN_KEYPAIR
 

--- a/integration-tests/test-repo/files/scripts/bluebuild.sh
+++ b/integration-tests/test-repo/files/scripts/bluebuild.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu
+mkdir -p /out/
+mv $CARGO_HOME/bin/bluebuild /out/bluebuild

--- a/integration-tests/test-repo/recipes/bluebuild.yml
+++ b/integration-tests/test-repo/recipes/bluebuild.yml
@@ -1,0 +1,15 @@
+stages:
+  - name: blue-build
+    image: rust
+    modules:
+      - type: containerfile
+        snippets:
+          - |
+            RUN cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu \
+              && mkdir -p /out/ \
+              && mv $CARGO_HOME/bin/bluebuild /out/bluebuild
+modules:
+  - type: copy
+    from: blue-build
+    src: /out/bluebuild
+    dest: /usr/bin/bluebuild

--- a/integration-tests/test-repo/recipes/bluebuild.yml
+++ b/integration-tests/test-repo/recipes/bluebuild.yml
@@ -1,6 +1,6 @@
 stages:
   - name: blue-build
-    image: rust:alpine
+    image: rust
     modules:
       - type: script
         scripts:

--- a/integration-tests/test-repo/recipes/bluebuild.yml
+++ b/integration-tests/test-repo/recipes/bluebuild.yml
@@ -1,13 +1,10 @@
 stages:
   - name: blue-build
-    image: rust
+    image: rust:alpine
     modules:
-      - type: containerfile
-        snippets:
-          - |
-            RUN cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu \
-              && mkdir -p /out/ \
-              && mv $CARGO_HOME/bin/bluebuild /out/bluebuild
+      - type: script
+        scripts:
+          - bluebuild.sh
 modules:
   - type: copy
     from: blue-build

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -40,3 +40,19 @@ modules:
       - RUN echo "This is a snippet" && ostree container commit
 
   - from-file: bluebuild.yml
+  - type: copy
+    from: alpine-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: ubuntu-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: debian-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: fedora-test
+    src: /test.txt
+    dest: /

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -1,10 +1,20 @@
 name: cli/test
-description: This is my personal OS image.
-base-image: ghcr.io/ublue-os/silverblue-main
 alt-tags:
   - gts
   - stable
+description: This is my personal OS image.
+base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 39
+stages:
+  - name: blue-build
+    image: rust
+    modules:
+      - type: containerfile
+        snippets:
+          - |
+            RUN cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu \
+              && mkdir -p /out/ \
+              && mv $CARGO_HOME/bin/bluebuild /out/bluebuild
 modules:
   - from-file: akmods.yml
   - from-file: flatpaks.yml
@@ -36,3 +46,8 @@ modules:
       - labels
     snippets:
       - RUN echo "This is a snippet" && ostree container commit
+
+  - type: copy
+    from: blue-build
+    src: /out/bluebuild
+    dest: /usr/bin/bluebuild

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -6,15 +6,7 @@ description: This is my personal OS image.
 base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 39
 stages:
-  - name: blue-build
-    image: rust
-    modules:
-      - type: containerfile
-        snippets:
-          - |
-            RUN cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu \
-              && mkdir -p /out/ \
-              && mv $CARGO_HOME/bin/bluebuild /out/bluebuild
+  - from-file: bluebuild.yml
 modules:
   - from-file: akmods.yml
   - from-file: flatpaks.yml
@@ -47,7 +39,4 @@ modules:
     snippets:
       - RUN echo "This is a snippet" && ostree container commit
 
-  - type: copy
-    from: blue-build
-    src: /out/bluebuild
-    dest: /usr/bin/bluebuild
+  - from-file: bluebuild.yml

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -6,7 +6,6 @@ description: This is my personal OS image.
 base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 39
 stages:
-  - from-file: bluebuild.yml
   - from-file: stages.yml
 modules:
   - from-file: akmods.yml
@@ -40,7 +39,6 @@ modules:
     snippets:
       - RUN echo "This is a snippet" && ostree container commit
 
-  - from-file: bluebuild.yml
   - type: copy
     from: alpine-test
     src: /test.txt

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -7,6 +7,7 @@ base-image: ghcr.io/ublue-os/silverblue-main
 image-version: 39
 stages:
   - from-file: bluebuild.yml
+  - from-file: stages.yml
 modules:
   - from-file: akmods.yml
   - from-file: flatpaks.yml

--- a/integration-tests/test-repo/recipes/stages.yml
+++ b/integration-tests/test-repo/recipes/stages.yml
@@ -1,18 +1,18 @@
 stages:
   - name: ubuntu-test
-    image: ubuntu
+    from: ubuntu
     modules:
       - from-file: stages.yml
   - name: debian-test
-    image: debian
+    from: debian
     modules:
       - from-file: stages.yml
   - name: fedora-test
-    image: fedora
+    from: fedora
     modules:
       - from-file: stages.yml
   - name: alpine-test
-    image: alpine
+    from: alpine
     modules:
       - from-file: stages.yml
 modules:

--- a/integration-tests/test-repo/recipes/stages.yml
+++ b/integration-tests/test-repo/recipes/stages.yml
@@ -22,10 +22,11 @@ modules:
   - type: script
     scripts:
       - example.sh
+    snippets:
+      - echo "test" > /test.txt
   - type: test-module
   - type: containerfile
     containerfiles:
       - labels
     snippets:
       - RUN echo "This is a snippet"
-

--- a/integration-tests/test-repo/recipes/stages.yml
+++ b/integration-tests/test-repo/recipes/stages.yml
@@ -1,0 +1,31 @@
+stages:
+  - name: ubuntu-test
+    image: ubuntu
+    modules:
+      - from-file: stages.yml
+  - name: debian-test
+    image: debian
+    modules:
+      - from-file: stages.yml
+  - name: fedora-test
+    image: fedora
+    modules:
+      - from-file: stages.yml
+  - name: alpine-test
+    image: alpine
+    modules:
+      - from-file: stages.yml
+modules:
+  - type: files
+    files:
+      - usr: /usr
+  - type: script
+    scripts:
+      - example.sh
+  - type: test-module
+  - type: containerfile
+    containerfiles:
+      - labels
+    snippets:
+      - RUN echo "This is a snippet"
+

--- a/modules.json
+++ b/modules.json
@@ -1,3 +1,4 @@
 [
-  "https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/containerfile/module.yml"
+  "https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/containerfile/module.yml",
+  "https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/copy/module.yml"
 ]

--- a/recipe/Cargo.toml
+++ b/recipe/Cargo.toml
@@ -14,6 +14,7 @@ chrono = "0.4"
 indexmap = { version = "2", features = ["serde"] }
 
 anyhow.workspace = true
+colored.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true

--- a/recipe/Cargo.toml
+++ b/recipe/Cargo.toml
@@ -21,5 +21,10 @@ serde_yaml.workspace = true
 serde_json.workspace = true
 typed-builder.workspace = true
 
+[features]
+default = []
+stages = []
+copy = []
+
 [lints]
 workspace = true

--- a/recipe/src/lib.rs
+++ b/recipe/src/lib.rs
@@ -2,8 +2,12 @@ pub mod akmods_info;
 pub mod module;
 pub mod module_ext;
 pub mod recipe;
+pub mod stage;
+pub mod stages_ext;
 
 pub use akmods_info::*;
 pub use module::*;
 pub use module_ext::*;
 pub use recipe::*;
+pub use stage::*;
+pub use stages_ext::*;

--- a/recipe/src/module.rs
+++ b/recipe/src/module.rs
@@ -93,9 +93,9 @@ impl<'a> Module<'a> {
     }
 
     #[must_use]
-    pub fn get_copy_args(&'a self) -> Option<(&'a str, &'a str, &'a str)> {
+    pub fn get_copy_args(&'a self) -> Option<(Option<&'a str>, &'a str, &'a str)> {
         Some((
-            self.config.get("from")?.as_str()?,
+            self.config.get("from").and_then(|from| from.as_str()),
             self.config.get("src")?.as_str()?,
             self.config.get("dest")?.as_str()?,
         ))

--- a/recipe/src/module.rs
+++ b/recipe/src/module.rs
@@ -89,6 +89,15 @@ impl<'a> Module<'a> {
     }
 
     #[must_use]
+    pub fn get_copy_args(&'a self) -> Option<(&'a str, &'a str, &'a str)> {
+        Some((
+            self.config.get("from")?.as_str()?,
+            self.config.get("src")?.as_str()?,
+            self.config.get("dest")?.as_str()?,
+        ))
+    }
+
+    #[must_use]
     pub fn generate_akmods_info(&'a self, os_version: &u64) -> AkmodsInfo {
         #[derive(Debug, Copy, Clone)]
         enum NvidiaAkmods {

--- a/recipe/src/module.rs
+++ b/recipe/src/module.rs
@@ -71,12 +71,21 @@ impl<'a> ModuleRequiredFields<'a> {
     }
 
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn get_copy_args(&'a self) -> Option<(Option<&'a str>, &'a str, &'a str)> {
-        Some((
-            self.config.get("from").and_then(|from| from.as_str()),
-            self.config.get("src")?.as_str()?,
-            self.config.get("dest")?.as_str()?,
-        ))
+        #[cfg(feature = "copy")]
+        {
+            Some((
+                self.config.get("from").and_then(|from| from.as_str()),
+                self.config.get("src")?.as_str()?,
+                self.config.get("dest")?.as_str()?,
+            ))
+        }
+
+        #[cfg(not(feature = "copy"))]
+        {
+            None
+        }
     }
 
     #[must_use]

--- a/recipe/src/module.rs
+++ b/recipe/src/module.rs
@@ -23,6 +23,10 @@ pub struct Module<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<Cow<'a, str>>,
 
+    #[builder(default)]
+    #[serde(rename = "no-cache", default)]
+    pub no_cache: bool,
+
     #[serde(flatten)]
     #[builder(default, setter(into))]
     pub config: IndexMap<String, Value>,

--- a/recipe/src/module_ext.rs
+++ b/recipe/src/module_ext.rs
@@ -15,7 +15,7 @@ pub struct ModuleExt<'a> {
 }
 
 impl ModuleExt<'_> {
-    /// # Parse a module file returning a [`ModuleExt`]
+    /// Parse a module file returning a [`ModuleExt`]
     ///
     /// # Errors
     /// Can return an `anyhow` Error if the file cannot be read or deserialized

--- a/recipe/src/module_ext.rs
+++ b/recipe/src/module_ext.rs
@@ -20,7 +20,7 @@ impl ModuleExt<'_> {
     /// # Errors
     /// Can return an `anyhow` Error if the file cannot be read or deserialized
     /// into a [`ModuleExt`]
-    pub fn parse_module_from_file(file_name: &str) -> Result<Self> {
+    pub fn parse(file_name: &Path) -> Result<Self> {
         let legacy_path = Path::new(CONFIG_PATH);
         let recipe_path = Path::new(RECIPE_PATH);
 
@@ -52,8 +52,20 @@ impl ModuleExt<'_> {
 
         self.modules
             .iter()
-            .filter(|module| module.module_type.as_ref().is_some_and(|t| t == "akmods"))
-            .map(|module| module.generate_akmods_info(os_version))
+            .filter(|module| {
+                module
+                    .required_fields
+                    .as_ref()
+                    .is_some_and(|rf| rf.module_type == "akmods")
+            })
+            .filter_map(|module| {
+                Some(
+                    module
+                        .required_fields
+                        .as_ref()?
+                        .generate_akmods_info(os_version),
+                )
+            })
             .filter(|image| seen.insert(image.clone()))
             .collect()
     }

--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -215,10 +215,10 @@ impl<'a> Recipe<'a> {
         let mut recipe = serde_yaml::from_str::<Recipe>(&file)
             .map_err(blue_build_utils::serde_yaml_err(&file))?;
 
-        recipe.modules_ext.modules = Module::get_modules(&recipe.modules_ext.modules)?.into();
+        recipe.modules_ext.modules = Module::get_modules(&recipe.modules_ext.modules, None)?.into();
 
         if let Some(ref mut stages_ext) = recipe.stages_ext {
-            stages_ext.stages = Stage::get_stages(&stages_ext.stages)?.into();
+            stages_ext.stages = Stage::get_stages(&stages_ext.stages, None)?.into();
         }
 
         Ok(recipe)

--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use typed_builder::TypedBuilder;
 
-use crate::{Module, ModuleExt};
+use crate::{Module, ModuleExt, StagesExt};
 
 /// The build recipe.
 ///
@@ -59,6 +59,14 @@ pub struct Recipe<'a> {
     #[serde(alias = "alt-tags", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub alt_tags: Option<Vec<Cow<'a, str>>>,
+
+    /// The stages extension of the recipe.
+    ///
+    /// This hold the list of stages that can
+    /// be used to build software outside of
+    /// the final build image.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub stages_ext: Option<StagesExt<'a>>,
 
     /// The modules extension of the recipe.
     ///

--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use typed_builder::TypedBuilder;
 
-use crate::{Module, ModuleExt, StagesExt};
+use crate::{Module, ModuleExt, Stage, StagesExt};
 
 /// The build recipe.
 ///
@@ -216,6 +216,10 @@ impl<'a> Recipe<'a> {
             .map_err(blue_build_utils::serde_yaml_err(&file))?;
 
         recipe.modules_ext.modules = Module::get_modules(&recipe.modules_ext.modules)?.into();
+
+        if let Some(ref mut stages_ext) = recipe.stages_ext {
+            stages_ext.stages = Stage::get_stages(&stages_ext.stages)?.into();
+        }
 
         Ok(recipe)
     }

--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use typed_builder::TypedBuilder;
 
-use crate::{Module, ModuleExt, Stage, StagesExt};
+use crate::{Module, ModuleExt, StagesExt};
 
 /// The build recipe.
 ///
@@ -217,8 +217,14 @@ impl<'a> Recipe<'a> {
 
         recipe.modules_ext.modules = Module::get_modules(&recipe.modules_ext.modules, None)?.into();
 
+        #[cfg(feature = "stages")]
         if let Some(ref mut stages_ext) = recipe.stages_ext {
-            stages_ext.stages = Stage::get_stages(&stages_ext.stages, None)?.into();
+            stages_ext.stages = crate::Stage::get_stages(&stages_ext.stages, None)?.into();
+        }
+
+        #[cfg(not(feature = "stages"))]
+        {
+            recipe.stages_ext = None;
         }
 
         Ok(recipe)

--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -1,10 +1,38 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, path::PathBuf};
 
 use anyhow::{bail, Result};
+use blue_build_utils::syntax_highlighting::highlight_ser;
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
-use crate::{ModuleExt, StagesExt};
+use crate::{Module, ModuleExt, StagesExt};
+
+/// Contains the required fields for a stage.
+#[derive(Serialize, Deserialize, Debug, Clone, TypedBuilder)]
+pub struct StageRequiredFields<'a> {
+    /// The name of the stage.
+    ///
+    /// This can then be referenced in the `copy`
+    /// module using the `from:` property.
+    #[builder(setter(into))]
+    pub name: Cow<'a, str>,
+
+    /// The base image of the stage.
+    ///
+    /// This is set directly in a `FROM` instruction.
+    #[builder(setter(into))]
+    pub image: Cow<'a, str>,
+
+    /// The shell to use in the stage.
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell: Option<Vec<Cow<'a, str>>>,
+
+    /// The modules extension for the stage
+    #[serde(flatten)]
+    pub modules_ext: ModuleExt<'a>,
+}
 
 /// Corresponds to a stage in a Containerfile
 ///
@@ -12,25 +40,10 @@ use crate::{ModuleExt, StagesExt};
 /// allows the user to reuse the modules thats provided to the main build.
 #[derive(Serialize, Deserialize, Debug, Clone, TypedBuilder)]
 pub struct Stage<'a> {
-    /// The name of the stage.
-    ///
-    /// This can then be referenced in the `copy`
-    /// module using the `from:` property.
-    #[builder(setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<Cow<'a, str>>,
-
-    /// The base image of the stage.
-    ///
-    /// This is set directly in a `FROM` instruction.
-    #[builder(setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub image: Option<Cow<'a, str>>,
-
-    /// The shell to use in the stage.
-    #[builder(setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub shell: Option<Vec<Cow<'a, str>>>,
+    /// The requied fields for a stage.
+    #[builder(default, setter(strip_option))]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub required_fields: Option<StageRequiredFields<'a>>,
 
     /// A reference to another recipe file containing
     /// one or more stages.
@@ -72,10 +85,6 @@ pub struct Stage<'a> {
     #[builder(default, setter(into, strip_option))]
     #[serde(rename = "from-file", skip_serializing_if = "Option::is_none")]
     pub from_file: Option<Cow<'a, str>>,
-
-    /// The modules extension for the stage
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub modules_ext: Option<ModuleExt<'a>>,
 }
 
 impl<'a> Stage<'a> {
@@ -85,24 +94,66 @@ impl<'a> Stage<'a> {
     /// Will error if the stage cannot be
     /// deserialized or the user uses another
     /// property alongside `from-file:`.
-    pub fn get_stages(stages: &[Self]) -> Result<Vec<Self>> {
+    pub fn get_stages(stages: &[Self], traversed_files: Option<Vec<PathBuf>>) -> Result<Vec<Self>> {
         let mut found_stages = vec![];
+        let traversed_files = traversed_files.unwrap_or_default();
+
         for stage in stages {
             found_stages.extend(
-                match stage.from_file.as_ref() {
-                    None => vec![stage.clone()],
-                    Some(file_name) => {
-                        if stage.name.is_some() || stage.image.is_some() || stage.shell.is_some() {
+                match stage {
+                    Stage {
+                        required_fields: Some(_),
+                        from_file: None,
+                    } => vec![stage.clone()],
+                    Stage {
+                        required_fields: None,
+                        from_file: Some(file_name),
+                    } => {
+                        let file_name = PathBuf::from(file_name.as_ref());
+                        if traversed_files.contains(&file_name) {
                             bail!(
-                                "You cannot use the `name:` or `image:` property with `from-file:`"
+                                "{} File {} has already been parsed:\n{traversed_files:?}",
+                                "Circular dependency detected!".bright_red(),
+                                file_name.display().to_string().bold(),
                             );
                         }
-                        Self::get_stages(&StagesExt::parse_stage_from_file(file_name)?.stages)?
+                        let mut tf = traversed_files.clone();
+                        tf.push(file_name.clone());
+
+                        Self::get_stages(&StagesExt::parse(&file_name)?.stages, Some(tf))?
+                    }
+                    _ => {
+                        let from_example = Stage::builder().from_file("path/to/stage.yml").build();
+                        let stage_example = Self::example();
+
+                        bail!(
+                            "Improper format for stage. Must be in the format like:\n{}\n{}\n\n{}",
+                            highlight_ser(&stage_example, "yaml", None)?,
+                            "or".bold(),
+                            highlight_ser(&from_example, "yaml", None)?
+                        );
                     }
                 }
                 .into_iter(),
             );
         }
         Ok(found_stages)
+    }
+
+    #[must_use]
+    pub fn example() -> Self {
+        Stage::builder()
+            .required_fields(
+                StageRequiredFields::builder()
+                    .name("stage-name")
+                    .image("build/image:here")
+                    .modules_ext(
+                        ModuleExt::builder()
+                            .modules(vec![Module::example()])
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
     }
 }

--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -92,7 +92,7 @@ impl<'a> Stage<'a> {
                 match stage.from_file.as_ref() {
                     None => vec![stage.clone()],
                     Some(file_name) => {
-                        if stage.name.is_some() || stage.image.is_some() {
+                        if stage.name.is_some() || stage.image.is_some() || stage.shell.is_some() {
                             bail!(
                                 "You cannot use the `name:` or `image:` property with `from-file:`"
                             );

--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -22,7 +22,7 @@ pub struct StageRequiredFields<'a> {
     ///
     /// This is set directly in a `FROM` instruction.
     #[builder(setter(into))]
-    pub image: Cow<'a, str>,
+    pub from: Cow<'a, str>,
 
     /// The shell to use in the stage.
     #[builder(default, setter(into, strip_option))]
@@ -146,7 +146,7 @@ impl<'a> Stage<'a> {
             .required_fields(
                 StageRequiredFields::builder()
                     .name("stage-name")
-                    .image("build/image:here")
+                    .from("build/image:here")
                     .modules_ext(
                         ModuleExt::builder()
                             .modules(vec![Module::example()])

--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -6,20 +6,74 @@ use typed_builder::TypedBuilder;
 
 use crate::{ModuleExt, StagesExt};
 
+/// Corresponds to a stage in a Containerfile
+///
+/// A stage has its own list of modules to run which
+/// allows the user to reuse the modules thats provided to the main build.
 #[derive(Serialize, Deserialize, Debug, Clone, TypedBuilder)]
 pub struct Stage<'a> {
+    /// The name of the stage.
+    ///
+    /// This can then be referenced in the `copy`
+    /// module using the `from:` property.
     #[builder(setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<Cow<'a, str>>,
 
+    /// The base image of the stage.
+    ///
+    /// This is set directly in a `FROM` instruction.
     #[builder(setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<Cow<'a, str>>,
 
+    /// The shell to use in the stage.
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell: Option<Vec<Cow<'a, str>>>,
+
+    /// A reference to another recipe file containing
+    /// one or more stages.
+    ///
+    /// An imported recipe file can contain just a single stage like:
+    ///
+    /// ```yaml
+    /// name: blue-build
+    /// image: rust
+    /// modules:
+    /// - type: containerfile
+    ///   snippets:
+    ///   - |
+    ///     RUN cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu \
+    ///       && mkdir -p /out/ \
+    ///       && mv $CARGO_HOME/bin/bluebuild /out/bluebuild
+    /// ```
+    ///
+    /// Or it can contain multiple stages:
+    ///
+    /// ```yaml
+    /// stages:
+    /// - name: blue-build
+    ///   image: rust
+    ///   modules:
+    ///   - type: containerfile
+    ///     snippets:
+    ///     - |
+    ///       RUN cargo install blue-build --debug --all-features --target x86_64-unknown-linux-gnu \
+    ///         && mkdir -p /out/ \
+    ///         && mv $CARGO_HOME/bin/bluebuild /out/bluebuild
+    /// - name: hello-world
+    ///   image: alpine
+    ///   modules:
+    ///   - type: script
+    ///     snippets:
+    ///     - echo "Hello World!"
+    /// ```
     #[builder(default, setter(into, strip_option))]
     #[serde(rename = "from-file", skip_serializing_if = "Option::is_none")]
     pub from_file: Option<Cow<'a, str>>,
 
+    /// The modules extension for the stage
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub modules_ext: Option<ModuleExt<'a>>,
 }

--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -1,0 +1,18 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+use crate::ModuleExt;
+
+#[derive(Serialize, Deserialize, Debug, Clone, TypedBuilder)]
+pub struct Stage<'a> {
+    #[builder(setter(into))]
+    pub name: Cow<'a, str>,
+
+    #[builder(setter(into))]
+    pub image: Cow<'a, str>,
+
+    #[serde(flatten)]
+    pub modules_ext: ModuleExt<'a>,
+}

--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -1,18 +1,54 @@
 use std::borrow::Cow;
 
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
-use crate::ModuleExt;
+use crate::{ModuleExt, StagesExt};
 
 #[derive(Serialize, Deserialize, Debug, Clone, TypedBuilder)]
 pub struct Stage<'a> {
-    #[builder(setter(into))]
-    pub name: Cow<'a, str>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<Cow<'a, str>>,
 
-    #[builder(setter(into))]
-    pub image: Cow<'a, str>,
+    #[builder(setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<Cow<'a, str>>,
 
-    #[serde(flatten)]
-    pub modules_ext: ModuleExt<'a>,
+    #[builder(default, setter(into, strip_option))]
+    #[serde(rename = "from-file", skip_serializing_if = "Option::is_none")]
+    pub from_file: Option<Cow<'a, str>>,
+
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub modules_ext: Option<ModuleExt<'a>>,
+}
+
+impl<'a> Stage<'a> {
+    /// Get's any child stages.
+    ///
+    /// # Errors
+    /// Will error if the stage cannot be
+    /// deserialized or the user uses another
+    /// property alongside `from-file:`.
+    pub fn get_stages(stages: &[Self]) -> Result<Vec<Self>> {
+        let mut found_stages = vec![];
+        for stage in stages {
+            found_stages.extend(
+                match stage.from_file.as_ref() {
+                    None => vec![stage.clone()],
+                    Some(file_name) => {
+                        if stage.name.is_some() || stage.image.is_some() {
+                            bail!(
+                                "You cannot use the `name:` or `image:` property with `from-file:`"
+                            );
+                        }
+                        Self::get_stages(&StagesExt::parse_stage_from_file(file_name)?.stages)?
+                    }
+                }
+                .into_iter(),
+            );
+        }
+        Ok(found_stages)
+    }
 }

--- a/recipe/src/stages_ext.rs
+++ b/recipe/src/stages_ext.rs
@@ -20,7 +20,7 @@ impl<'a> StagesExt<'a> {
     /// # Errors
     /// Can return an `anyhow` Error if the file cannot be read or deserialized
     /// into a [`StagesExt`]
-    pub fn parse_stage_from_file(file_name: &str) -> Result<Self> {
+    pub fn parse(file_name: &Path) -> Result<Self> {
         let legacy_path = Path::new(CONFIG_PATH);
         let recipe_path = Path::new(RECIPE_PATH);
 
@@ -38,8 +38,9 @@ impl<'a> StagesExt<'a> {
             |_| -> Result<Self> {
                 let mut stage = serde_yaml::from_str::<Stage>(&file)
                     .map_err(blue_build_utils::serde_yaml_err(&file))?;
-                if let Some(ref mut modules_ext) = stage.modules_ext {
-                    modules_ext.modules = Module::get_modules(&modules_ext.modules)?.into();
+                if let Some(ref mut rf) = stage.required_fields {
+                    rf.modules_ext.modules =
+                        Module::get_modules(&rf.modules_ext.modules, None)?.into();
                 }
                 Ok(Self::builder().stages(vec![stage]).build())
             },
@@ -47,8 +48,9 @@ impl<'a> StagesExt<'a> {
                 let mut stages: Vec<Stage> =
                     stages_ext.stages.iter().map(ToOwned::to_owned).collect();
                 for stage in &mut stages {
-                    if let Some(ref mut modules_ext) = stage.modules_ext {
-                        modules_ext.modules = Module::get_modules(&modules_ext.modules)?.into();
+                    if let Some(ref mut rf) = stage.required_fields {
+                        rf.modules_ext.modules =
+                            Module::get_modules(&rf.modules_ext.modules, None)?.into();
                     }
                 }
                 stages_ext.stages = stages.into();

--- a/recipe/src/stages_ext.rs
+++ b/recipe/src/stages_ext.rs
@@ -1,0 +1,11 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+use crate::Stage;
+
+#[derive(Default, Serialize, Clone, Deserialize, Debug, TypedBuilder)]
+pub struct StagesExt<'a> {
+    pub stages: Cow<'a, [Stage<'a>]>,
+}

--- a/recipe/src/stages_ext.rs
+++ b/recipe/src/stages_ext.rs
@@ -1,5 +1,8 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, fs, path::Path};
 
+use anyhow::{Context, Result};
+use blue_build_utils::constants::{CONFIG_PATH, RECIPE_PATH};
+use log::warn;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
@@ -7,5 +10,37 @@ use crate::Stage;
 
 #[derive(Default, Serialize, Clone, Deserialize, Debug, TypedBuilder)]
 pub struct StagesExt<'a> {
+    #[builder(default, setter(into))]
     pub stages: Cow<'a, [Stage<'a>]>,
+}
+
+impl<'a> StagesExt<'a> {
+    /// # Parse a module file returning a [`ModuleExt`]
+    ///
+    /// # Errors
+    /// Can return an `anyhow` Error if the file cannot be read or deserialized
+    /// into a [`ModuleExt`]
+    pub fn parse_stage_from_file(file_name: &str) -> Result<Self> {
+        let legacy_path = Path::new(CONFIG_PATH);
+        let recipe_path = Path::new(RECIPE_PATH);
+
+        let file_path = if recipe_path.exists() && recipe_path.is_dir() {
+            recipe_path.join(file_name)
+        } else {
+            warn!("Use of {CONFIG_PATH} for recipes is deprecated, please move your recipe files into {RECIPE_PATH}");
+            legacy_path.join(file_name)
+        };
+
+        let file = fs::read_to_string(&file_path)
+            .context(format!("Failed to open {}", file_path.display()))?;
+
+        serde_yaml::from_str::<Self>(&file).map_or_else(
+            |_| -> Result<Self> {
+                let stage = serde_yaml::from_str::<Stage>(&file)
+                    .map_err(blue_build_utils::serde_yaml_err(&file))?;
+                Ok(Self::builder().stages(vec![stage]).build())
+            },
+            Ok,
+        )
+    }
 }

--- a/recipe/src/stages_ext.rs
+++ b/recipe/src/stages_ext.rs
@@ -15,11 +15,11 @@ pub struct StagesExt<'a> {
 }
 
 impl<'a> StagesExt<'a> {
-    /// # Parse a module file returning a [`ModuleExt`]
+    /// Parse a module file returning a [`StagesExt`]
     ///
     /// # Errors
     /// Can return an `anyhow` Error if the file cannot be read or deserialized
-    /// into a [`ModuleExt`]
+    /// into a [`StagesExt`]
     pub fn parse_stage_from_file(file_name: &str) -> Result<Self> {
         let legacy_path = Path::new(CONFIG_PATH);
         let recipe_path = Path::new(RECIPE_PATH);

--- a/scripts/run_module.sh
+++ b/scripts/run_module.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-source /tmp/exports.sh
+source /tmp/scripts/exports.sh
 
 # Function to print a centered text banner within a specified width
 print_banner() {

--- a/scripts/run_module.sh
+++ b/scripts/run_module.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source /tmp/exports.sh
+
 # Function to print a centered text banner within a specified width
 print_banner() {
   local term_width=120
@@ -29,4 +31,3 @@ print_banner "Start $(title_case ${module}) Module"
 chmod +x ${script_path}
 ${script_path} "${params}"
 print_banner "End $(title_case ${module}) Module"
-ostree container commit

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,13 +7,13 @@ if [ -f /etc/os-release ]; then
     echo "Setting up Alpine based image to run BlueBuild modules"
     apk update
     apk add --no-cache bash curl coreutils wget
-  elif [ "$ID" = "ubuntu" ]; then
+  elif [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     echo "Setting up Ubuntu based image to run BlueBuild modules"
     apt-get update
-    apt-get install -y bash curl
+    apt-get install -y bash curl coreutils wget
   elif [ "$ID" = "fedora" ]; then
     echo "Settig up Fedora based image to run BlueBuild modules"
-    dnf install -y --refresh bash curl wget
+    dnf install -y --refresh bash curl wget coreutils
   else
     echo "OS not detected, exiting"
     exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,7 +17,5 @@ if [ -f /etc/os-release ]; then
   else
     echo "OS not detected, proceeding without setup"
   fi
-else
-  echo "File /etc/os-release not found, proceeding without setup"
 fi
 cp /tmp/bins/yq /usr/bin/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,7 @@ if [ -f /etc/os-release ]; then
   if [ "$ID" = "alpine" ]; then
     echo "Setting up Alpine based image to run BlueBuild modules"
     apk update
-    apk add --no-cache bash curl coreutils wget
+    apk add --no-cache bash curl coreutils wget grep
   elif [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     echo "Setting up Ubuntu based image to run BlueBuild modules"
     apt-get update

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,7 @@ if [ -f /etc/os-release ]; then
     echo "OS not detected, exiting"
     exit 1
   fi
+  cp /tmp/bins/yq /usr/bin/
 else
   echo "File /etc/os-release not found, can't proceed"
   exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,11 +15,9 @@ if [ -f /etc/os-release ]; then
     echo "Settig up Fedora based image to run BlueBuild modules"
     dnf install -y --refresh bash curl wget coreutils
   else
-    echo "OS not detected, exiting"
-    exit 1
+    echo "OS not detected, proceeding without setup"
   fi
   cp /tmp/bins/yq /usr/bin/
 else
-  echo "File /etc/os-release not found, can't proceed"
-  exit 1
+  echo "File /etc/os-release not found, proceeding without setup"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,12 +11,13 @@ if [ -f /etc/os-release ]; then
     echo "Setting up Ubuntu based image to run BlueBuild modules"
     apt-get update
     apt-get install -y bash curl
-  elif [ "$ID" = "fedora" ]
+  elif [ "$ID" = "fedora" ]; then
     echo "Settig up Fedora based image to run BlueBuild modules"
     dnf install -y --refresh bash curl wget
   else
     echo "OS not detected, exiting"
     exit 1
+  fi
 else
   echo "File /etc/os-release not found, can't proceed"
   exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,7 +17,7 @@ if [ -f /etc/os-release ]; then
   else
     echo "OS not detected, proceeding without setup"
   fi
-  cp /tmp/bins/yq /usr/bin/
 else
   echo "File /etc/os-release not found, proceeding without setup"
 fi
+cp /tmp/bins/yq /usr/bin/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ -f /etc/os-release ]; then
+  export ID="$(cat /etc/os-release | grep -E '^ID=' | awk -F '=' '{print $2}')"
+
+  if [ "$ID" = "alpine" ]; then
+    echo "Setting up Alpine based image to run BlueBuild modules"
+    apk update
+    apk add --no-cache bash curl coreutils wget
+  elif [ "$ID" = "ubuntu" ]; then
+    echo "Setting up Ubuntu based image to run BlueBuild modules"
+    apt-get update
+    apt-get install -y bash curl
+  elif [ "$ID" = "fedora" ]
+    echo "Settig up Fedora based image to run BlueBuild modules"
+    dnf install -y --refresh bash curl wget
+  else
+    echo "OS not detected, exiting"
+    exit 1
+else
+  echo "File /etc/os-release not found, can't proceed"
+  exit 1
+fi

--- a/src/drivers/opts/build.rs
+++ b/src/drivers/opts/build.rs
@@ -37,7 +37,7 @@ pub struct PushOpts<'a> {
 pub struct BuildTagPushOpts<'a> {
     /// The base image name.
     ///
-    /// NOTE: You cannot have this set with `archive-path` set.
+    /// NOTE: You cannot have this set with `archive_path` set.
     #[builder(default, setter(into, strip_option))]
     pub image: Option<Cow<'a, str>>,
 

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 pub use askama::Template;
 
 #[derive(Debug, Clone, Template, TypedBuilder)]
-#[template(path = "Containerfile.j2", escape = "none")]
+#[template(path = "Containerfile.j2", escape = "none", whitespace = "minimize")]
 pub struct ContainerFileTemplate<'a> {
     recipe: &'a Recipe<'a>,
 

--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -1,3 +1,4 @@
+{%- import "modules/modules.j2" as modules -%}
 {%- set files_dir_exists = self::files_dir_exists() %}
 {%- include "stages.j2" %}
 
@@ -15,7 +16,19 @@ ARG MODULE_DIRECTORY="/tmp/modules"
 ARG IMAGE_NAME="{{ recipe.name }}"
 ARG BASE_IMAGE="{{ recipe.base_image }}"
 
-{% include "modules/modules.j2" %}
+# Key RUN
+RUN --mount=type=bind,from=stage-keys,src=/keys,dst=/tmp/keys \
+  mkdir -p /usr/etc/pki/containers/ \
+  && cp /tmp/keys/* /usr/etc/pki/containers/ \
+  && ostree container commit
+
+# Bin RUN
+RUN --mount=type=bind,from=stage-bins,src=/bins,dst=/tmp/bins \
+  mkdir -p /usr/bin/ \
+  && cp /tmp/bins/* /usr/bin/ \
+  && ostree container commit
+
+{% call modules::main_modules_run(recipe.modules_ext, os_version) %}
 
 RUN rm -fr /tmp/* /var/* && ostree container commit
 

--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -2,7 +2,7 @@
 {%- set files_dir_exists = self::files_dir_exists() %}
 {%- include "stages.j2" %}
 
-FROM {{ recipe.base_image }}:{{ recipe.image_version }}
+FROM {{ recipe.base_image }}:{{ recipe.image_version }} as {{ recipe.name|replace('/', "-") }}
 
 ARG RECIPE={{ recipe_path.display() }}
 ARG IMAGE_REGISTRY={{ registry }}

--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -2,6 +2,7 @@
 {%- set files_dir_exists = self::files_dir_exists() %}
 {%- include "stages.j2" %}
 
+# Main image
 FROM {{ recipe.base_image }}:{{ recipe.image_version }} as {{ recipe.name|replace('/', "-") }}
 
 ARG RECIPE={{ recipe_path.display() }}

--- a/template/templates/modules/akmods/akmods.j2
+++ b/template/templates/modules/akmods/akmods.j2
@@ -1,4 +1,5 @@
 {%- for info in recipe.modules_ext.get_akmods_info_list(os_version) %}
+# Stage for AKmod {{ info.stage_name }}
 FROM scratch as stage-akmods-{{ info.stage_name }}
 COPY --from=ghcr.io/ublue-os/{{ info.images.0 }} /rpms /rpms
 COPY --from=ghcr.io/ublue-os/{{ info.images.1 }} /rpms /rpms

--- a/template/templates/modules/containerfile/README.md
+++ b/template/templates/modules/containerfile/README.md
@@ -4,7 +4,7 @@
 Only compiler-based builds can use this module as it is built-in to the BlueBuild CLI tool.
 :::
 
-The `containerfile` module is a tool for adding custom [`Containerfile`](https://github.com/containers/common/blob/main/docs/Containerfile.5.md) instructions for custom image builds. This is useful when you wish to use some feature directly available in a `Containerfile`, but not in a bash module, such as copying from other OCI images with `COPY --from`.
+The `containerfile` module is a tool for adding custom [`Containerfile`](https://github.com/containers/common/blob/main/docs/Containerfile.5.md) instructions for custom image builds. This is useful when you wish to use some feature directly available in a `Containerfile`, but not in a bash module, such as using a `RUN` instruction with custom mounts.
 
 Since standard compiler-based BlueBuild image builds generate a `Containerfile` from your recipe, there is no need to manage it yourself. However, we know that we also have technical users that would like to have the ability to customize their `Containerfile`. This is where the `containerfile` module comes into play. 
 
@@ -18,10 +18,10 @@ The `snippets` property is the easiest to use when you just need to insert a few
 modules:
   - type: containerfile
     snippets:
-      - COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
+      - RUN --mount=type=tmpfs,target=/tmp /some/script.sh
 ```
 
-This makes it really easy to copy a file or program from another image.
+This makes it really easy to add individual, custom instructions.
 
 :::note
 **NOTE:** Each entry of a snippet will be its own layer in the final `Containerfile`.
@@ -66,7 +66,7 @@ If you wanted to have some `snippets` run before any `containerfiles` have, you 
 modules:
   - type: containerfile
     snippets:
-      - COPY --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/yq
+      - RUN --mount=type=tmpfs,target=/tmp /some/script.sh
   - type: containerfile
     containerfiles:
       - example

--- a/template/templates/modules/containerfile/module.yml
+++ b/template/templates/modules/containerfile/module.yml
@@ -4,7 +4,7 @@ readme: https://raw.githubusercontent.com/blue-build/cli/main/template/templates
 example: |
   type: containerfile
   snippets:
-    - COPY ./config/example-dir/example-file.txt /usr/etc/example/
+    - RUN --mount=type=tmpfs,target=/tmp /some/script.sh
   containerfiles:
     - example
     - subroutine

--- a/template/templates/modules/copy/README.md
+++ b/template/templates/modules/copy/README.md
@@ -1,0 +1,40 @@
+# `copy`
+
+:::caution
+Only compiler-based builds can use this module as it is built-in to the BlueBuild CLI tool.
+:::
+
+The `copy` module is a short-hand method of adding a [`COPY`]() instruction into the image. This can be used to copy files from images, other stages, or even from the build context. 
+
+## Usage
+
+The `copy` module's properties are a 1-1 match with the `COPY` instruction containing `src`, `dest`, and `from` (optional). The example below will `COPY` the file `/usr/bin/yq` from `docker.io/mikefarah/yq` into `/usr/bin/`.
+
+```yaml
+mdoules:
+- type: copy
+  from: docker.io/mikefarah/yq
+  src: /usr/bin/yq
+  dest: /usr/bin/
+```
+
+Creating an instruction like:
+
+```dockerfile
+COPY --linked --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/
+```
+
+Omitting `from:` will allow copying from the build context:
+
+```yaml
+mdoules:
+- type: copy
+  src: file/to/copy.conf
+  dest: /usr/etc/app/
+```
+
+Creating an instruction like:
+
+```dockerfile
+COPY --linked file/to/copy.conf /usr/etc/app/
+```

--- a/template/templates/modules/copy/README.md
+++ b/template/templates/modules/copy/README.md
@@ -4,6 +4,10 @@
 Only compiler-based builds can use this module as it is built-in to the BlueBuild CLI tool.
 :::
 
+:::note
+**NOTE:** This module is currently only available with the `use_unstable_cli` option on the GHA or using the `main` image.
+:::
+
 The `copy` module is a short-hand method of adding a [`COPY`]() instruction into the image. This can be used to copy files from images, other stages, or even from the build context. 
 
 ## Usage

--- a/template/templates/modules/copy/README.md
+++ b/template/templates/modules/copy/README.md
@@ -8,7 +8,7 @@ Only compiler-based builds can use this module as it is built-in to the BlueBuil
 **NOTE:** This module is currently only available with the `use_unstable_cli` option on the GHA or using the `main` image.
 :::
 
-The `copy` module is a short-hand method of adding a [`COPY`]() instruction into the image. This can be used to copy files from images, other stages, or even from the build context. 
+The `copy` module is a short-hand method of adding a [`COPY`](https://docs.docker.com/reference/dockerfile/#copy) instruction into the image. This can be used to copy files from images, other stages, or even from the build context. 
 
 ## Usage
 

--- a/template/templates/modules/copy/copy.j2
+++ b/template/templates/modules/copy/copy.j2
@@ -1,4 +1,4 @@
 {%- if let Some((from_img, src, dest)) = module.get_copy_args() %}
-COPY --link{% if let Some(from_img) = from_img %} --from={{ from_img }}{% endif %} {{ src }} {{ dest }}
+COPY{% if let Some(from_img) = from_img %} --from={{ from_img }}{% endif %} {{ src }} {{ dest }}
 {%- endif %}
 

--- a/template/templates/modules/copy/copy.j2
+++ b/template/templates/modules/copy/copy.j2
@@ -1,0 +1,4 @@
+{%- if let Some((from_img, src, dest)) = module.get_copy_args() %}
+COPY --from={{ from_img }} {{ src }} {{ dest }}
+{%- endif %}
+

--- a/template/templates/modules/copy/copy.j2
+++ b/template/templates/modules/copy/copy.j2
@@ -1,4 +1,4 @@
 {%- if let Some((from_img, src, dest)) = module.get_copy_args() %}
-COPY --from={{ from_img }} {{ src }} {{ dest }}
+COPY --link --from={{ from_img }} {{ src }} {{ dest }}
 {%- endif %}
 

--- a/template/templates/modules/copy/copy.j2
+++ b/template/templates/modules/copy/copy.j2
@@ -1,4 +1,4 @@
 {%- if let Some((from_img, src, dest)) = module.get_copy_args() %}
-COPY --link --from={{ from_img }} {{ src }} {{ dest }}
+COPY --link{% if let Some(from_img) = from_img %} --from={{ from_img }}{% endif %} {{ src }} {{ dest }}
 {%- endif %}
 

--- a/template/templates/modules/copy/module.yml
+++ b/template/templates/modules/copy/module.yml
@@ -1,0 +1,8 @@
+name: copy
+shortdesc: The copy module is a direct translation of the `COPY` instruction in a Containerfile.
+readme: https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/copy/README.md
+example: |
+  type: copy
+  from: docker.io/mikefarah/yq
+  src: /usr/bin/yq
+  dest: /usr/bin/

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -23,8 +23,8 @@ RUN \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
   --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
-  source /tmp/scripts/exports.sh \
-  && /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
+  /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}' \
+  && ostree container commit
       {%- endif %}
     {%- endif %}
   {%- endfor %}
@@ -51,8 +51,8 @@ RUN \
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
-  source /tmp/scripts/exports.sh \
-  && /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
+  --mount=type=bind,from=stage-bins,src=/bins/yq,dst=/usr/bin/yq \
+  /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
       {%- endif %}
     {%- endif %}
   {%- endfor %}

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -23,7 +23,7 @@ RUN \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
   --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
-  /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}' \
+  /tmp/scripts/run_module.sh '{{ type }}' '{{ module.print_module_context() }}' \
   && ostree container commit
       {%- endif %}
     {%- endif %}
@@ -51,7 +51,7 @@ RUN \
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
-  /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
+  /tmp/scripts/run_module.sh '{{ type }}' '{{ module.print_module_context() }}'
       {%- endif %}
     {%- endif %}
   {%- endfor %}

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -1,15 +1,14 @@
 {% macro main_modules_run(modules_ext, os_version) %}
 # Module RUNs
   {%- for module in modules_ext.modules %}
-
-    {%- if module.no_cache %}
+    {%- if let Some(module) = module.required_fields %}
+      {%- if module.no_cache %}
 ARG CACHEBUST="{{ build_id }}"
-    {%- endif %}
+      {%- endif %}
 
-    {%- if let Some(type) = module.module_type %}
-      {%- if type == "containerfile" %}
+      {%- if module.module_type == "containerfile" %}
         {%- include "modules/containerfile/containerfile.j2" %}
-      {%- else if type == "copy" %}
+      {%- else if module.module_type == "copy" %}
         {%- include "modules/copy/copy.j2" %}
       {%- else %}
 RUN \
@@ -23,12 +22,12 @@ RUN \
         {%- else %}
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
         {%- endif %}
-        {%- if type == "akmods" %}
+        {%- if module.module_type == "akmods" %}
   --mount=type=bind,from=stage-akmods-{{ module.generate_akmods_info(os_version).stage_name }},src=/rpms,dst=/tmp/rpms,rw \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
   --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
-  /tmp/scripts/run_module.sh '{{ type }}' '{{ module.print_module_context() }}' \
+  /tmp/scripts/run_module.sh '{{ module.module_type }}' '{{ module.print_module_context() }}' \
   && ostree container commit
       {%- endif %}
     {%- endif %}
@@ -38,15 +37,15 @@ RUN \
 {% macro stage_modules_run(modules_ext, os_version) %}
 # Module RUNs
   {%- for module in modules_ext.modules %}
+    {%- if let Some(module) = module.required_fields %}
 
-    {%- if module.no_cache %}
+      {%- if module.no_cache %}
 ARG CACHEBUST="{{ build_id }}"
-    {%- endif %}
+      {%- endif %}
 
-    {%- if let Some(type) = module.module_type %}
-      {%- if type == "containerfile" %}
+      {%- if module.module_type == "containerfile" %}
         {%- include "modules/containerfile/containerfile.j2" %}
-      {%- else if type == "copy" %}
+      {%- else if module.module_type == "copy" %}
         {%- include "modules/copy/copy.j2" %}
       {%- else %}
 RUN \
@@ -61,7 +60,7 @@ RUN \
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
-  /tmp/scripts/run_module.sh '{{ type }}' '{{ module.print_module_context() }}'
+  /tmp/scripts/run_module.sh '{{ module.module_type }}' '{{ module.print_module_context() }}'
       {%- endif %}
     {%- endif %}
   {%- endfor %}

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -1,6 +1,11 @@
 {% macro main_modules_run(modules_ext, os_version) %}
 # Module RUNs
   {%- for module in modules_ext.modules %}
+
+    {%- if module.no_cache %}
+ARG CACHEBUST="{{ build_id }}"
+    {%- endif %}
+
     {%- if let Some(type) = module.module_type %}
       {%- if type == "containerfile" %}
         {%- include "modules/containerfile/containerfile.j2" %}
@@ -33,6 +38,11 @@ RUN \
 {% macro stage_modules_run(modules_ext, os_version) %}
 # Module RUNs
   {%- for module in modules_ext.modules %}
+
+    {%- if module.no_cache %}
+ARG CACHEBUST="{{ build_id }}"
+    {%- endif %}
+
     {%- if let Some(type) = module.module_type %}
       {%- if type == "containerfile" %}
         {%- include "modules/containerfile/containerfile.j2" %}

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -33,7 +33,6 @@ RUN \
     {%- endif %}
   {%- endfor %}
 {% endmacro %}
-
 {% macro stage_modules_run(modules_ext, os_version) %}
 # Module RUNs
   {%- for module in modules_ext.modules %}

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -51,7 +51,6 @@ RUN \
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
         {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
-  --mount=type=bind,from=stage-bins,src=/bins/yq,dst=/usr/bin/yq \
   /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
       {%- endif %}
     {%- endif %}

--- a/template/templates/modules/modules.j2
+++ b/template/templates/modules/modules.j2
@@ -1,41 +1,59 @@
-# Key RUN
-RUN --mount=type=bind,from=stage-keys,src=/keys,dst=/tmp/keys \
-  mkdir -p /usr/etc/pki/containers/ \
-  && cp /tmp/keys/* /usr/etc/pki/containers/ \
-  && ostree container commit
-
-# Bin RUN
-RUN --mount=type=bind,from=stage-bins,src=/bins,dst=/tmp/bins \
-  mkdir -p /usr/bin/ \
-  && cp /tmp/bins/* /usr/bin/ \
-  && ostree container commit
-
+{% macro main_modules_run(modules_ext, os_version) %}
 # Module RUNs
-{%- for module in recipe.modules_ext.modules %}
-  {%- if let Some(type) = module.module_type %}
-    {%- if type == "containerfile" %}
-      {%- include "modules/containerfile/containerfile.j2" %}
-    {%- else %}
+  {%- for module in modules_ext.modules %}
+    {%- if let Some(type) = module.module_type %}
+      {%- if type == "containerfile" %}
+        {%- include "modules/containerfile/containerfile.j2" %}
+      {%- else if type == "copy" %}
+        {%- include "modules/copy/copy.j2" %}
+      {%- else %}
 RUN \
-      {%- if files_dir_exists %}
+        {%- if files_dir_exists %}
   --mount=type=bind,from=stage-files,src=/files,dst=/tmp/files,rw \
-      {%- else %}
+        {%- else %}
   --mount=type=bind,from=stage-config,src=/config,dst=/tmp/config,rw \
-      {%- endif %}
-      {%- if let Some(source) = module.source %}
+        {%- endif %}
+        {%- if let Some(source) = module.source %}
   --mount=type=bind,from={{ source }},src=/modules,dst=/tmp/modules,rw \
-      {%- else %}
+        {%- else %}
   --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
-      {%- endif %}
-      {%- if type == "akmods" %}
+        {%- endif %}
+        {%- if type == "akmods" %}
   --mount=type=bind,from=stage-akmods-{{ module.generate_akmods_info(os_version).stage_name }},src=/rpms,dst=/tmp/rpms,rw \
-      {%- endif %}
+        {%- endif %}
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
   --mount=type=cache,dst=/var/cache/rpm-ostree,id=rpm-ostree-cache-{{ recipe.name }}-{{ recipe.image_version }},sharing=locked \
   source /tmp/scripts/exports.sh \
   && /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
+      {%- endif %}
     {%- endif %}
-  {%- endif %}
-{%- endfor %}
+  {%- endfor %}
+{% endmacro %}
 
-
+{% macro stage_modules_run(modules_ext, os_version) %}
+# Module RUNs
+  {%- for module in modules_ext.modules %}
+    {%- if let Some(type) = module.module_type %}
+      {%- if type == "containerfile" %}
+        {%- include "modules/containerfile/containerfile.j2" %}
+      {%- else if type == "copy" %}
+        {%- include "modules/copy/copy.j2" %}
+      {%- else %}
+RUN \
+        {%- if files_dir_exists %}
+  --mount=type=bind,from=stage-files,src=/files,dst=/tmp/files,rw \
+        {%- else %}
+  --mount=type=bind,from=stage-config,src=/config,dst=/tmp/config,rw \
+        {%- endif %}
+        {%- if let Some(source) = module.source %}
+  --mount=type=bind,from={{ source }},src=/modules,dst=/tmp/modules,rw \
+        {%- else %}
+  --mount=type=bind,from=stage-modules,src=/modules,dst=/tmp/modules,rw \
+        {%- endif %}
+  --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
+  source /tmp/scripts/exports.sh \
+  && /tmp/scripts/run_module.sh {{ type }} '{{ module.print_module_context() }}'
+      {%- endif %}
+    {%- endif %}
+  {%- endfor %}
+{% endmacro %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -54,6 +54,10 @@ COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
     {%- if let (Some(image), Some(name), Some(modules_ext)) = (stage.image.as_ref(), stage.name.as_ref(), stage.modules_ext.as_ref()) %}
 FROM {{ image }} as {{ name }}
 
+RUN --mount=type=bind,from=stage-bins,src=/bins/,dst=/tmp/bins/ \
+  --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
+  /tmp/scripts/setup.sh
+
       {%- if files_dir_exists %}
 ARG CONFIG_DIRECTORY="/tmp/files"
       {%- else %}
@@ -63,6 +67,8 @@ ARG MODULE_DIRECTORY="/tmp/modules"
 
       {%- if let Some(shell_args) = stage.shell %}
 SHELL [{% for arg in shell_args %}"{{ arg }}"{% if !loop.last %}, {% endif %}{% endfor %}]
+      {%- else %}
+SHELL ["bash", "-c"]
       {%- endif %}
 
       {% call modules::stage_modules_run(modules_ext, os_version) %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -48,10 +48,23 @@ COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 
 {%- include "modules/akmods/akmods.j2" %}
 
+{%- set files_dir_exists = self::files_dir_exists() %}
 {%~ if let Some(stages_ext) = recipe.stages_ext %}
   {%- for stage in stages_ext.stages %}
     {%- if let (Some(image), Some(name), Some(modules_ext)) = (stage.image.as_ref(), stage.name.as_ref(), stage.modules_ext.as_ref()) %}
 FROM {{ image }} as {{ name }}
+
+      {%- if files_dir_exists %}
+ARG CONFIG_DIRECTORY="/tmp/files"
+      {%- else %}
+ARG CONFIG_DIRECTORY="/tmp/config"
+      {%- endif %}
+ARG MODULE_DIRECTORY="/tmp/modules"
+
+      {%- if let Some(shell_args) = stage.shell %}
+SHELL [{% for arg in shell_args %}"{{ arg }}"{% if !loop.last %}, {% endif %}{% endfor %}]
+      {%- endif %}
+
       {% call modules::stage_modules_run(modules_ext, os_version) %}
     {%- endif %}
   {%- endfor %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -47,3 +47,10 @@ COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 {%- endif %}
 
 {%- include "modules/akmods/akmods.j2" %}
+
+{%~ if let Some(stages_ext) = recipe.stages_ext %}
+  {%- for stage in stages_ext.stages %}
+FROM {{ stage.image }} as {{ stage.name }}
+    {% call modules::stage_modules_run(stage.modules_ext, os_version) %}
+  {%- endfor %}
+{%- endif %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -3,19 +3,19 @@
 # the final image
 {%- if files_dir_exists %}
 FROM scratch AS stage-files
-COPY --link ./files /files
+COPY ./files /files
 {% else %}
 FROM scratch AS stage-config
-COPY --link ./config /config
+COPY ./config /config
 {% endif %}
 
 # Copy modules
 # The default modules are inside blue-build/modules
 # Custom modules overwrite defaults
 FROM scratch AS stage-modules
-COPY --link --from=ghcr.io/blue-build/modules:latest /modules /modules
+COPY --from=ghcr.io/blue-build/modules:latest /modules /modules
 {%- if self::modules_exists() %}
-COPY --link ./modules /modules
+COPY ./modules /modules
 {% endif %}
 
 # Bins to install
@@ -24,9 +24,9 @@ COPY --link ./modules /modules
 # stage process so that adding the bins into the image
 # can be added to the ostree commits.
 FROM scratch AS stage-bins
-COPY --link --from=gcr.io/projectsigstore/cosign /ko-app/cosign /bins/cosign
-COPY --link --from=docker.io/mikefarah/yq /usr/bin/yq /bins/yq
-COPY --link --from=ghcr.io/blue-build/cli:
+COPY --from=gcr.io/projectsigstore/cosign /ko-app/cosign /bins/cosign
+COPY --from=docker.io/mikefarah/yq /usr/bin/yq /bins/yq
+COPY --from=ghcr.io/blue-build/cli:
 {%- if let Some(tag) = recipe.blue_build_tag -%}
 {{ tag }}
 {%- else -%}
@@ -41,7 +41,7 @@ latest-installer
 # public key.
 FROM scratch AS stage-keys
 {%- if self::has_cosign_file() %}
-COPY --link cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
+COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 {% endif %}
 
 {%- include "modules/akmods/akmods.j2" %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -51,11 +51,11 @@ COPY --link cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 {%- set files_dir_exists = self::files_dir_exists() %}
 {%~ if let Some(stages_ext) = recipe.stages_ext %}
   {%- for stage in stages_ext.stages %}
-    {%- if let (Some(image), Some(name), Some(modules_ext)) = (stage.image.as_ref(), stage.name.as_ref(), stage.modules_ext.as_ref()) %}
-# {{ name|capitalize }} stage
-FROM {{ image }} as {{ name }}
+    {%- if let Some(stage) = stage.required_fields %}
+# {{ stage.name|capitalize }} stage
+FROM {{ stage.image }} as {{ stage.name }}
 
-      {%- if image.as_ref() != "scratch" %}
+      {%- if stage.image != "scratch" %}
 # Add compatibility for modules
 RUN --mount=type=bind,from=stage-bins,src=/bins/,dst=/tmp/bins/ \
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
@@ -75,7 +75,7 @@ SHELL ["bash", "-c"]
         {%- endif %}
       {%- endif %}
 
-      {% call modules::stage_modules_run(modules_ext, os_version) %}
+      {% call modules::stage_modules_run(stage.modules_ext, os_version) %}
     {%- endif %}
   {%- endfor %}
 {%- endif %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -2,29 +2,28 @@
 # your config without copying it directly into
 # the final image
 {%- if files_dir_exists %}
-FROM scratch as stage-files
+FROM scratch AS stage-files
 COPY --link ./files /files
-{%- else %}
-FROM scratch as stage-config
+{% else %}
+FROM scratch AS stage-config
 COPY --link ./config /config
-{%- endif %}
+{% endif %}
 
 # Copy modules
 # The default modules are inside blue-build/modules
 # Custom modules overwrite defaults
-FROM scratch as stage-modules
+FROM scratch AS stage-modules
 COPY --link --from=ghcr.io/blue-build/modules:latest /modules /modules
 {%- if self::modules_exists() %}
 COPY --link ./modules /modules
-{%- endif %}
+{% endif %}
 
 # Bins to install
 # These are basic tools that are added to all images.
 # Generally used for the build process. We use a multi
 # stage process so that adding the bins into the image
 # can be added to the ostree commits.
-FROM scratch as stage-bins
-
+FROM scratch AS stage-bins
 COPY --link --from=gcr.io/projectsigstore/cosign /ko-app/cosign /bins/cosign
 COPY --link --from=docker.io/mikefarah/yq /usr/bin/yq /bins/yq
 COPY --link --from=ghcr.io/blue-build/cli:
@@ -40,11 +39,10 @@ latest-installer
 #
 # Currently only holds the current image's
 # public key.
-FROM scratch as stage-keys
-
+FROM scratch AS stage-keys
 {%- if self::has_cosign_file() %}
 COPY --link cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
-{%- endif %}
+{% endif %}
 
 {%- include "modules/akmods/akmods.j2" %}
 
@@ -53,7 +51,7 @@ COPY --link cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
   {%- for stage in stages_ext.stages %}
     {%- if let Some(stage) = stage.required_fields %}
 # {{ stage.name|capitalize }} stage
-FROM {{ stage.from }} as {{ stage.name }}
+FROM {{ stage.from }} AS {{ stage.name }}
 
       {%- if stage.from != "scratch" %}
 # Add compatibility for modules

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -50,7 +50,9 @@ COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 
 {%~ if let Some(stages_ext) = recipe.stages_ext %}
   {%- for stage in stages_ext.stages %}
-FROM {{ stage.image }} as {{ stage.name }}
-    {% call modules::stage_modules_run(stage.modules_ext, os_version) %}
+    {%- if let (Some(image), Some(name), Some(modules_ext)) = (stage.image.as_ref(), stage.name.as_ref(), stage.modules_ext.as_ref()) %}
+FROM {{ image }} as {{ name }}
+      {% call modules::stage_modules_run(modules_ext, os_version) %}
+    {%- endif %}
   {%- endfor %}
 {%- endif %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -53,9 +53,9 @@ COPY --link cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
   {%- for stage in stages_ext.stages %}
     {%- if let Some(stage) = stage.required_fields %}
 # {{ stage.name|capitalize }} stage
-FROM {{ stage.image }} as {{ stage.name }}
+FROM {{ stage.from }} as {{ stage.name }}
 
-      {%- if stage.image != "scratch" %}
+      {%- if stage.from != "scratch" %}
 # Add compatibility for modules
 RUN --mount=type=bind,from=stage-bins,src=/bins/,dst=/tmp/bins/ \
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -54,21 +54,23 @@ COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
     {%- if let (Some(image), Some(name), Some(modules_ext)) = (stage.image.as_ref(), stage.name.as_ref(), stage.modules_ext.as_ref()) %}
 FROM {{ image }} as {{ name }}
 
+      {%- if image.as_ref() != "scratch" %}
 RUN --mount=type=bind,from=stage-bins,src=/bins/,dst=/tmp/bins/ \
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
   /tmp/scripts/setup.sh
 
-      {%- if files_dir_exists %}
+        {%- if files_dir_exists %}
 ARG CONFIG_DIRECTORY="/tmp/files"
-      {%- else %}
+        {%- else %}
 ARG CONFIG_DIRECTORY="/tmp/config"
-      {%- endif %}
+        {%- endif %}
 ARG MODULE_DIRECTORY="/tmp/modules"
 
-      {%- if let Some(shell_args) = stage.shell %}
+        {%- if let Some(shell_args) = stage.shell %}
 SHELL [{% for arg in shell_args %}"{{ arg }}"{% if !loop.last %}, {% endif %}{% endfor %}]
-      {%- else %}
+        {%- else %}
 SHELL ["bash", "-c"]
+        {%- endif %}
       {%- endif %}
 
       {% call modules::stage_modules_run(modules_ext, os_version) %}

--- a/template/templates/stages.j2
+++ b/template/templates/stages.j2
@@ -3,19 +3,19 @@
 # the final image
 {%- if files_dir_exists %}
 FROM scratch as stage-files
-COPY ./files /files
+COPY --link ./files /files
 {%- else %}
 FROM scratch as stage-config
-COPY ./config /config
+COPY --link ./config /config
 {%- endif %}
 
 # Copy modules
 # The default modules are inside blue-build/modules
 # Custom modules overwrite defaults
 FROM scratch as stage-modules
-COPY --from=ghcr.io/blue-build/modules:latest /modules /modules
+COPY --link --from=ghcr.io/blue-build/modules:latest /modules /modules
 {%- if self::modules_exists() %}
-COPY ./modules /modules
+COPY --link ./modules /modules
 {%- endif %}
 
 # Bins to install
@@ -25,9 +25,9 @@ COPY ./modules /modules
 # can be added to the ostree commits.
 FROM scratch as stage-bins
 
-COPY --from=gcr.io/projectsigstore/cosign /ko-app/cosign /bins/cosign
-COPY --from=docker.io/mikefarah/yq /usr/bin/yq /bins/yq
-COPY --from=ghcr.io/blue-build/cli:
+COPY --link --from=gcr.io/projectsigstore/cosign /ko-app/cosign /bins/cosign
+COPY --link --from=docker.io/mikefarah/yq /usr/bin/yq /bins/yq
+COPY --link --from=ghcr.io/blue-build/cli:
 {%- if let Some(tag) = recipe.blue_build_tag -%}
 {{ tag }}
 {%- else -%}
@@ -43,7 +43,7 @@ latest-installer
 FROM scratch as stage-keys
 
 {%- if self::has_cosign_file() %}
-COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
+COPY --link cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 {%- endif %}
 
 {%- include "modules/akmods/akmods.j2" %}
@@ -52,9 +52,11 @@ COPY cosign.pub /keys/{{ recipe.name|replace('/', "_") }}.pub
 {%~ if let Some(stages_ext) = recipe.stages_ext %}
   {%- for stage in stages_ext.stages %}
     {%- if let (Some(image), Some(name), Some(modules_ext)) = (stage.image.as_ref(), stage.name.as_ref(), stage.modules_ext.as_ref()) %}
+# {{ name|capitalize }} stage
 FROM {{ image }} as {{ name }}
 
       {%- if image.as_ref() != "scratch" %}
+# Add compatibility for modules
 RUN --mount=type=bind,from=stage-bins,src=/bins/,dst=/tmp/bins/ \
   --mount=type=bind,from=ghcr.io/blue-build/cli:{{ exports_tag }}-build-scripts,src=/scripts/,dst=/tmp/scripts/ \
   /tmp/scripts/setup.sh


### PR DESCRIPTION
## Stages

A new property (`stages`) is being added to the recipe file schema. This property will allow users to define a list of Containerfile stages each with their own modules. Stages can be used to compile programs, perform parallel operations, and copy the results into the final image without contaminating the final image.

### Module Support

Currently the only modules that work out-of-the-box are `copy`, `script`, `files`, and `containerfile`. Other modules are dependent on the programs installed on the image. In order to better support some of our essential modules, a setup script is ran at the start of each stage that is not `scratch`. This script will install `curl`, `wget`, `bash`, and `grep` and use the package manager for the detected distributions.

At this time, the following distributions are supported:

- Debian
- Ubuntu
- Fedora
- Alpine

Contributions to increase the size of this list is [welcome](https://github.com/blue-build/cli)!

### Syntax

- **Required**
  - `from` - The full image ref (image name + tag). This will be set in the `FROM` statement of the stage.
  - `name` - The name of the stage. This is used when referencing the stage when using the `from:` property in the `copy` module.
  - `modules` - The list of modules to execute. The exact same syntax used by the main recipe `modules:` property.
- **Optional**
  -  `shell` - Allows a user to pass in an array of strings that are passed directly into the [`SHELL` instruction](https://docs.docker.com/reference/dockerfile/#shell).

#### Example

```yaml
stages:
- name: ubuntu-test
  from: ubuntu
  modules:
  - type: files
    files:
    - usr: /usr
  - type: script
    scripts:
    - example.sh
    snippets:
    - echo "test" > /test.txt
  - type: test-module
  - type: containerfile
    containerfiles:
    - labels
    snippets:
    - RUN echo "This is a snippet"
```

### Tasks
- [x] `from-file:` - Allows the user to store their stages in a separate file so it can be included in multiple recipes
- [x] `no-cache:` - This will be useful for stages that want to pull the latest changes from a git repo and not have to rely on the base image getting an update for the build to be triggered again.
- [x] Add setup script to be able to install necessary programs to run `bluebuild` modules in stages
- [x] Check for circular dependencies and error out

## `copy` module

This is a 1-1 for the [`COPY` instruction](https://docs.docker.com/reference/dockerfile/#copy). It has the ability to copy files between stages, making this a very important addition to complete functionality for the stages feature. Each use of this "module" will become its own layer. 

### Syntax

- **Required**
  - `src` - The source directory/file from the repo OR when `from:` is set the image/stage that is specified.
  - `dest` - The destination directory/file inside the working image.
- **Optional**
  - `from` - The stage/image to copy from.

#### Example

```yaml
modules:
- type: copy
  from: ubuntu-test
  src: /test.txt
  dest: /
```

### Tasks
- [x] make `from:` optional
- [x] Add README.md and module.yml

## Feature gating

Gating this feature until we release for `v0.9.0`. The plan will be to build all features (including this one) for main branch builds. This means that these features will be available when using the `main` image and consequently the `use_unstable_cli:` option on the GitHub Action. All future `v0.9.0` features will be gated as well to allow for patches to `v0.8`.

### Tasks
- [x] Build `--all-features` on non-tagged builds
- [x] Add stages and copy features