### PR TITLE
refactor: Create CiDriver

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,6 +13,16 @@ env:
   RUST_LOG_STYLE: always
 
 jobs:
+  event:
+    name: Event
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Event
+        run: cat "$GITHUB_EVENT_PATH"
   arm64-prebuild:
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,16 +13,6 @@ env:
   RUST_LOG_STYLE: always
 
 jobs:
-  event:
-    name: Event
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    steps:
-      - name: Event
-        run: cat "$GITHUB_EVENT_PATH"
   arm64-prebuild:
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/Earthfile
+++ b/Earthfile
@@ -40,6 +40,8 @@ lint:
 
 test:
 	FROM +common
+	COPY --dir test-files/ integration-tests/ /app
+
 	DO rust+CARGO --args="test -- --show-output"
 	DO rust+CARGO --args="test --all-features -- --show-output"
 	DO rust+CARGO --args="test --no-default-features -- --show-output"

--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -1,12 +1,7 @@
-use std::{borrow::Cow, env, fs, path::Path};
+use std::{borrow::Cow, fs, path::Path};
 
-use blue_build_utils::constants::{
-    CI_COMMIT_REF_NAME, CI_COMMIT_SHORT_SHA, CI_DEFAULT_BRANCH, CI_MERGE_REQUEST_IID,
-    CI_PIPELINE_SOURCE, GITHUB_EVENT_NAME, GITHUB_REF_NAME, GITHUB_SHA, PR_EVENT_NUMBER,
-};
-use chrono::Local;
 use indexmap::IndexMap;
-use log::{debug, trace, warn};
+use log::{debug, trace};
 use miette::{Context, IntoDiagnostic, Result};
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
@@ -83,116 +78,6 @@ pub struct Recipe<'a> {
 }
 
 impl<'a> Recipe<'a> {
-    /// Generate a list of tags based on the OS version.
-    ///
-    /// ## CI
-    /// The tags are generated based on the CI system that
-    /// is detected. The general format for the default branch is:
-    /// - `${os_version}`
-    /// - `${timestamp}-${os_version}`
-    ///
-    /// On a branch:
-    /// - `br-${branch_name}-${os_version}`
-    ///
-    /// In a PR(GitHub)/MR(GitLab)
-    /// - `pr-${pr_event_number}-${os_version}`/`mr-${mr_iid}-${os_version}`
-    ///
-    /// In all above cases the short git sha is also added:
-    /// - `${commit_sha}-${os_version}`
-    ///
-    /// When `alt_tags` are not present, the following tags are added:
-    /// - `latest`
-    /// - `${timestamp}`
-    ///
-    /// ## Locally
-    /// When ran locally, only a local tag is created:
-    /// - `local-${os_version}`
-    #[must_use]
-    pub fn generate_tags(&self, os_version: u64) -> Vec<String> {
-        trace!("Recipe::generate_tags()");
-        trace!("Generating image tags for {}", &self.name);
-
-        let mut tags: Vec<String> = Vec::new();
-        let timestamp = Local::now().format("%Y%m%d").to_string();
-
-        if let (Ok(commit_branch), Ok(default_branch), Ok(commit_sha), Ok(pipeline_source)) = (
-            env::var(CI_COMMIT_REF_NAME),
-            env::var(CI_DEFAULT_BRANCH),
-            env::var(CI_COMMIT_SHORT_SHA),
-            env::var(CI_PIPELINE_SOURCE),
-        ) {
-            trace!("CI_COMMIT_REF_NAME={commit_branch}, CI_DEFAULT_BRANCH={default_branch},CI_COMMIT_SHORT_SHA={commit_sha}, CI_PIPELINE_SOURCE={pipeline_source}");
-            warn!("Detected running in Gitlab, pulling information from CI variables");
-
-            if let Ok(mr_iid) = env::var(CI_MERGE_REQUEST_IID) {
-                trace!("CI_MERGE_REQUEST_IID={mr_iid}");
-                if pipeline_source == "merge_request_event" {
-                    debug!("Running in a MR");
-                    tags.push(format!("mr-{mr_iid}-{os_version}"));
-                }
-            }
-
-            if default_branch == commit_branch {
-                debug!("Running on the default branch");
-                tags.push(os_version.to_string());
-                tags.push(format!("{timestamp}-{os_version}"));
-
-                if let Some(alt_tags) = self.alt_tags.as_ref() {
-                    tags.extend(alt_tags.iter().map(ToString::to_string));
-                } else {
-                    tags.push("latest".into());
-                    tags.push(timestamp);
-                }
-            } else {
-                debug!("Running on branch {commit_branch}");
-                tags.push(format!("br-{commit_branch}-{os_version}"));
-            }
-
-            tags.push(format!("{commit_sha}-{os_version}"));
-        } else if let (
-            Ok(github_event_name),
-            Ok(github_event_number),
-            Ok(github_sha),
-            Ok(github_ref_name),
-        ) = (
-            env::var(GITHUB_EVENT_NAME),
-            env::var(PR_EVENT_NUMBER),
-            env::var(GITHUB_SHA),
-            env::var(GITHUB_REF_NAME),
-        ) {
-            trace!("GITHUB_EVENT_NAME={github_event_name},PR_EVENT_NUMBER={github_event_number},GITHUB_SHA={github_sha},GITHUB_REF_NAME={github_ref_name}");
-            warn!("Detected running in Github, pulling information from GITHUB variables");
-
-            let mut short_sha = github_sha;
-            short_sha.truncate(7);
-
-            if github_event_name == "pull_request" {
-                debug!("Running in a PR");
-                tags.push(format!("pr-{github_event_number}-{os_version}"));
-            } else if github_ref_name == "live" || github_ref_name == "main" {
-                tags.push(os_version.to_string());
-                tags.push(format!("{timestamp}-{os_version}"));
-
-                if let Some(alt_tags) = self.alt_tags.as_ref() {
-                    tags.extend(alt_tags.iter().map(ToString::to_string));
-                } else {
-                    tags.push("latest".into());
-                    tags.push(timestamp);
-                }
-            } else {
-                tags.push(format!("br-{github_ref_name}-{os_version}"));
-            }
-            tags.push(format!("{short_sha}-{os_version}"));
-        } else {
-            warn!("Running locally");
-            tags.push(format!("local-{os_version}"));
-        }
-        debug!("Finished generating tags!");
-        debug!("Tags: {tags:#?}");
-
-        tags.into_iter().map(|t| t.replace('/', "_")).collect()
-    }
-
     /// Parse a recipe file
     ///
     /// # Errors

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -331,10 +331,10 @@ impl CiDriver for Driver<'_> {
         }
     }
 
-    fn cert_identity() -> Result<String> {
+    fn keyless_cert_identity() -> Result<String> {
         match Self::get_ci_driver() {
             CiDriverType::Local => todo!(),
-            CiDriverType::Gitlab => GitlabDriver::cert_identity(),
+            CiDriverType::Gitlab => GitlabDriver::keyless_cert_identity(),
             CiDriverType::Github => todo!(),
         }
     }

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -354,6 +354,14 @@ impl CiDriver for Driver<'_> {
         }
     }
 
+    fn oidc_provider() -> Result<String> {
+        match Self::get_ci_driver() {
+            CiDriverType::Local => LocalDriver::oidc_provider(),
+            CiDriverType::Gitlab => GitlabDriver::oidc_provider(),
+            CiDriverType::Github => GithubDriver::oidc_provider(),
+        }
+    }
+
     fn generate_tags(recipe: &Recipe) -> Result<Vec<String>> {
         match Self::get_ci_driver() {
             CiDriverType::Local => LocalDriver::generate_tags(recipe),

--- a/src/drivers/github_driver.rs
+++ b/src/drivers/github_driver.rs
@@ -2,7 +2,6 @@ use std::{env, fs, path::PathBuf};
 
 use blue_build_utils::constants::GITHUB_EVENT_PATH;
 use event::Event;
-use log::trace;
 
 use super::CiDriver;
 
@@ -18,8 +17,14 @@ impl CiDriver for GithubDriver {
             .and_then(|event_path| {
                 let event: Event =
                     serde_json::from_str(&fs::read_to_string(event_path).ok()?).ok()?;
-                trace!("{event:?}");
-                todo!()
+                Some(match (event.commit_ref, event.head) {
+                    (Some(commit_ref), _) => {
+                        commit_ref.trim_start_matches("refs/heads/")
+                            == event.repository.default_branch
+                    }
+                    (_, Some(head)) => event.repository.default_branch == head.commit_ref,
+                    _ => false,
+                })
             })
             .unwrap_or(false)
     }

--- a/src/drivers/github_driver.rs
+++ b/src/drivers/github_driver.rs
@@ -1,54 +1,304 @@
-use std::{env, fs, path::PathBuf};
+use std::env;
 
-use blue_build_utils::constants::GITHUB_EVENT_PATH;
+use blue_build_utils::constants::{
+    GITHUB_EVENT_NAME, GITHUB_REF_NAME, GITHUB_SHA, GITHUB_WORKFLOW_REF, PR_EVENT_NUMBER,
+};
 use event::Event;
+use log::trace;
+use miette::{Context, IntoDiagnostic};
 
-use super::CiDriver;
+use super::{CiDriver, Driver};
 
 mod event;
 
 pub struct GithubDriver;
 
 impl CiDriver for GithubDriver {
-    fn on_main_branch() -> bool {
-        env::var(GITHUB_EVENT_PATH)
-            .ok()
-            .map(PathBuf::from)
-            .and_then(|event_path| {
-                let event: Event =
-                    serde_json::from_str(&fs::read_to_string(event_path).ok()?).ok()?;
-                Some(match (event.commit_ref, event.head) {
-                    (Some(commit_ref), _) => {
-                        commit_ref.trim_start_matches("refs/heads/")
-                            == event.repository.default_branch
-                    }
-                    (_, Some(head)) => event.repository.default_branch == head.commit_ref,
-                    _ => false,
-                })
-            })
-            .unwrap_or(false)
+    fn on_default_branch() -> bool {
+        Event::try_new().map_or_else(
+            |_| false,
+            |event| match (event.commit_ref, event.head) {
+                (Some(commit_ref), _) => {
+                    commit_ref.trim_start_matches("refs/heads/") == event.repository.default_branch
+                }
+                (_, Some(head)) => event.repository.default_branch == head.commit_ref,
+                _ => false,
+            },
+        )
     }
 
     fn keyless_cert_identity() -> miette::Result<String> {
-        todo!()
+        env::var(GITHUB_WORKFLOW_REF).into_diagnostic()
     }
 
-    fn generate_tags<T, S>(
-        _recipe: &blue_build_recipe::Recipe,
-        _alt_tags: Option<T>,
-    ) -> miette::Result<Vec<String>>
-    where
-        T: AsRef<[S]>,
-        S: AsRef<str>,
-    {
-        todo!()
+    fn generate_tags(recipe: &blue_build_recipe::Recipe) -> miette::Result<Vec<String>> {
+        let mut tags: Vec<String> = Vec::new();
+        let os_version = Driver::get_os_version(recipe)?;
+        let github_event_name = env::var(GITHUB_EVENT_NAME)
+            .into_diagnostic()
+            .with_context(|| format!("Failed to get {GITHUB_EVENT_NAME}'"))?;
+
+        if github_event_name == "pull_request" {
+            trace!("Running in a PR");
+
+            let github_event_number = env::var(PR_EVENT_NUMBER)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get {PR_EVENT_NUMBER}'"))?;
+
+            tags.push(format!("pr-{github_event_number}-{os_version}"));
+        } else if Self::on_default_branch() {
+            tags.push(os_version.to_string());
+
+            let timestamp = blue_build_utils::get_tag_timestamp();
+            tags.push(format!("{timestamp}-{os_version}"));
+
+            if let Some(ref alt_tags) = recipe.alt_tags {
+                tags.extend(alt_tags.iter().map(ToString::to_string));
+            } else {
+                tags.push("latest".into());
+                tags.push(timestamp);
+            }
+        } else {
+            let github_ref_name = env::var(GITHUB_REF_NAME)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{GITHUB_REF_NAME}'"))?;
+
+            tags.push(format!("br-{github_ref_name}-{os_version}"));
+        }
+
+        let mut short_sha = env::var(GITHUB_SHA)
+            .into_diagnostic()
+            .with_context(|| format!("Failed to get {GITHUB_SHA}'"))?;
+        short_sha.truncate(7);
+
+        tags.push(format!("{short_sha}-{os_version}"));
+
+        Ok(tags)
     }
 
     fn get_repo_url() -> miette::Result<String> {
-        todo!()
+        Ok(Event::try_new()?.repository.html_url)
     }
 
     fn get_registry() -> miette::Result<String> {
-        todo!()
+        Ok(format!(
+            "ghcr.io/{}",
+            Event::try_new()?.repository.owner.login
+        ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::env;
+
+    use blue_build_utils::constants::{
+        GITHUB_EVENT_NAME, GITHUB_EVENT_PATH, GITHUB_REF_NAME, GITHUB_SHA, PR_EVENT_NUMBER,
+    };
+
+    use crate::{
+        drivers::CiDriver,
+        test::{create_test_recipe, BB_UNIT_TEST_MOCK_GET_OS_VERSION, ENV_LOCK},
+    };
+
+    use super::GithubDriver;
+
+    #[test]
+    fn get_registry() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "./test-files/github-events/default-branch.json",
+        );
+
+        let registry = GithubDriver::get_registry().unwrap();
+
+        assert_eq!(registry, "ghcr.io/test-owner");
+
+        env::remove_var(GITHUB_EVENT_PATH);
+    }
+
+    #[test]
+    fn on_default_branch_true() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "./test-files/github-events/default-branch.json",
+        );
+
+        assert!(GithubDriver::on_default_branch());
+        env::remove_var(GITHUB_EVENT_PATH);
+    }
+
+    #[test]
+    fn on_default_branch_false() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "./test-files/github-events/pr-branch.json",
+        );
+
+        assert!(!GithubDriver::on_default_branch());
+        env::remove_var(GITHUB_EVENT_PATH);
+    }
+
+    #[test]
+    fn get_repo_url() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "./test-files/github-events/default-branch.json",
+        );
+
+        let url = GithubDriver::get_repo_url().unwrap();
+
+        assert_eq!(url, "https://example.com/");
+        env::remove_var(GITHUB_EVENT_PATH);
+    }
+
+    #[test]
+    fn generate_tags_default_branch() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let timestamp = blue_build_utils::get_tag_timestamp();
+        let cd = env::current_dir().unwrap();
+
+        env::set_var(GITHUB_EVENT_NAME, "push");
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "../../test-files/github-events/default-branch.json",
+        );
+        env::set_var(GITHUB_REF_NAME, "main");
+        env::set_var(GITHUB_SHA, "1234567890");
+        env::set_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION, "");
+        env::set_current_dir("./integration-tests/test-repo/").unwrap();
+
+        let mut tags = GithubDriver::generate_tags(&create_test_recipe()).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec![
+            format!("{timestamp}-40"),
+            "latest".to_string(),
+            timestamp,
+            "1234567-40".to_string(),
+            "40".to_string(),
+        ];
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        env::remove_var(GITHUB_EVENT_NAME);
+        env::remove_var(GITHUB_EVENT_PATH);
+        env::remove_var(GITHUB_REF_NAME);
+        env::remove_var(GITHUB_SHA);
+        env::remove_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION);
+        env::set_current_dir(cd).unwrap();
+    }
+
+    #[test]
+    fn generate_tags_default_branch_alt_tags() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let timestamp = blue_build_utils::get_tag_timestamp();
+        let cd = env::current_dir().unwrap();
+
+        env::set_var(GITHUB_EVENT_NAME, "push");
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "../../test-files/github-events/default-branch.json",
+        );
+        env::set_var(GITHUB_REF_NAME, "main");
+        env::set_var(GITHUB_SHA, "1234567890");
+        env::set_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION, "");
+        env::set_current_dir("./integration-tests/test-repo/").unwrap();
+
+        let mut recipe = create_test_recipe();
+
+        recipe.alt_tags = Some(vec!["test-tag1".into(), "test-tag2".into()]);
+
+        let mut tags = GithubDriver::generate_tags(&recipe).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec![
+            format!("{timestamp}-40"),
+            "1234567-40".to_string(),
+            "40".to_string(),
+        ];
+        expected_tags.extend(recipe.alt_tags.unwrap().iter().map(ToString::to_string));
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        env::remove_var(GITHUB_EVENT_NAME);
+        env::remove_var(GITHUB_EVENT_PATH);
+        env::remove_var(GITHUB_REF_NAME);
+        env::remove_var(GITHUB_SHA);
+        env::remove_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION);
+        env::set_current_dir(cd).unwrap();
+    }
+
+    #[test]
+    fn generate_tags_pr_branch() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let cd = env::current_dir().unwrap();
+
+        env::set_var(GITHUB_EVENT_NAME, "pull_request");
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "../../test-files/github-events/pr-branch.json",
+        );
+        env::set_var(GITHUB_REF_NAME, "test-branch");
+        env::set_var(GITHUB_SHA, "1234567890");
+        env::set_var(PR_EVENT_NUMBER, "12");
+        env::set_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION, "");
+        env::set_current_dir("./integration-tests/test-repo/").unwrap();
+
+        let mut tags = GithubDriver::generate_tags(&create_test_recipe()).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec!["pr-12-40".to_string(), "1234567-40".to_string()];
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        env::remove_var(GITHUB_EVENT_NAME);
+        env::remove_var(GITHUB_EVENT_PATH);
+        env::remove_var(GITHUB_REF_NAME);
+        env::remove_var(GITHUB_SHA);
+        env::remove_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION);
+        env::set_current_dir(cd).unwrap();
+    }
+
+    #[test]
+    fn generate_tags_branch() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let cd = env::current_dir().unwrap();
+
+        env::set_var(GITHUB_EVENT_NAME, "push");
+        env::set_var(
+            GITHUB_EVENT_PATH,
+            "../../test-files/github-events/branch.json",
+        );
+        env::set_var(GITHUB_REF_NAME, "test-branch");
+        env::set_var(GITHUB_SHA, "1234567890");
+        env::set_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION, "");
+        env::set_current_dir("./integration-tests/test-repo/").unwrap();
+
+        let mut tags = GithubDriver::generate_tags(&create_test_recipe()).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec!["1234567-40".to_string(), "br-test-branch-40".to_string()];
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        env::remove_var(GITHUB_EVENT_NAME);
+        env::remove_var(GITHUB_EVENT_PATH);
+        env::remove_var(GITHUB_REF_NAME);
+        env::remove_var(GITHUB_SHA);
+        env::remove_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION);
+        env::set_current_dir(cd).unwrap();
     }
 }

--- a/src/drivers/github_driver.rs
+++ b/src/drivers/github_driver.rs
@@ -29,7 +29,7 @@ impl CiDriver for GithubDriver {
             .unwrap_or(false)
     }
 
-    fn cert_identity() -> miette::Result<String> {
+    fn keyless_cert_identity() -> miette::Result<String> {
         todo!()
     }
 

--- a/src/drivers/github_driver.rs
+++ b/src/drivers/github_driver.rs
@@ -1,0 +1,32 @@
+use super::CiDriver;
+
+pub struct GithubDriver;
+
+impl CiDriver for GithubDriver {
+    fn on_main_branch() -> bool {
+        todo!()
+    }
+
+    fn cert_identity() -> miette::Result<String> {
+        todo!()
+    }
+
+    fn generate_tags<T, S>(
+        _recipe: &blue_build_recipe::Recipe,
+        _alt_tags: Option<T>,
+    ) -> miette::Result<Vec<String>>
+    where
+        T: AsRef<[S]>,
+        S: AsRef<str>,
+    {
+        todo!()
+    }
+
+    fn get_repo_url() -> miette::Result<String> {
+        todo!()
+    }
+
+    fn get_registry() -> miette::Result<String> {
+        todo!()
+    }
+}

--- a/src/drivers/github_driver.rs
+++ b/src/drivers/github_driver.rs
@@ -1,10 +1,27 @@
+use std::{env, fs, path::PathBuf};
+
+use blue_build_utils::constants::GITHUB_EVENT_PATH;
+use event::Event;
+use log::trace;
+
 use super::CiDriver;
+
+mod event;
 
 pub struct GithubDriver;
 
 impl CiDriver for GithubDriver {
     fn on_main_branch() -> bool {
-        todo!()
+        env::var(GITHUB_EVENT_PATH)
+            .ok()
+            .map(PathBuf::from)
+            .and_then(|event_path| {
+                let event: Event =
+                    serde_json::from_str(&fs::read_to_string(event_path).ok()?).ok()?;
+                trace!("{event:?}");
+                todo!()
+            })
+            .unwrap_or(false)
     }
 
     fn cert_identity() -> miette::Result<String> {

--- a/src/drivers/github_driver/event.rs
+++ b/src/drivers/github_driver/event.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct Event {
+    pub repository: EventRepository,
+    // pub base: Option<EventRefInfo>,
+    pub head: Option<EventRefInfo>,
+
+    #[serde(alias = "ref")]
+    pub commit_ref: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct EventRepository {
+    pub default_branch: String,
+    // pub owner: EventRepositoryOwner,
+}
+
+// #[derive(Debug, Deserialize)]
+// pub(super) struct EventRepositoryOwner {
+//     pub login: String,
+// }
+
+#[derive(Debug, Deserialize)]
+pub(super) struct EventRefInfo {
+    #[serde(alias = "ref")]
+    pub commit_ref: String,
+}

--- a/src/drivers/github_driver/event.rs
+++ b/src/drivers/github_driver/event.rs
@@ -1,6 +1,6 @@
-use std::{env, fs, path::PathBuf};
+use std::{fs, path::PathBuf};
 
-use blue_build_utils::constants::GITHUB_EVENT_PATH;
+use blue_build_utils::{constants::GITHUB_EVENT_PATH, get_env_var};
 use miette::{IntoDiagnostic, Result};
 use serde::Deserialize;
 
@@ -16,8 +16,7 @@ pub(super) struct Event {
 
 impl Event {
     pub fn try_new() -> Result<Self> {
-        env::var(GITHUB_EVENT_PATH)
-            .into_diagnostic()
+        get_env_var(GITHUB_EVENT_PATH)
             .map(PathBuf::from)
             .and_then(|event_path| {
                 serde_json::from_str::<Self>(&fs::read_to_string(event_path).into_diagnostic()?)

--- a/src/drivers/github_driver/event.rs
+++ b/src/drivers/github_driver/event.rs
@@ -1,6 +1,10 @@
+use std::{env, fs, path::PathBuf};
+
+use blue_build_utils::constants::GITHUB_EVENT_PATH;
+use miette::{IntoDiagnostic, Result};
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub(super) struct Event {
     pub repository: EventRepository,
     // pub base: Option<EventRefInfo>,
@@ -10,18 +14,31 @@ pub(super) struct Event {
     pub commit_ref: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-pub(super) struct EventRepository {
-    pub default_branch: String,
-    // pub owner: EventRepositoryOwner,
+impl Event {
+    pub fn try_new() -> Result<Self> {
+        env::var(GITHUB_EVENT_PATH)
+            .into_diagnostic()
+            .map(PathBuf::from)
+            .and_then(|event_path| {
+                serde_json::from_str::<Self>(&fs::read_to_string(event_path).into_diagnostic()?)
+                    .into_diagnostic()
+            })
+    }
 }
 
-// #[derive(Debug, Deserialize)]
-// pub(super) struct EventRepositoryOwner {
-//     pub login: String,
-// }
+#[derive(Debug, Deserialize, Clone)]
+pub(super) struct EventRepository {
+    pub default_branch: String,
+    pub owner: EventRepositoryOwner,
+    pub html_url: String,
+}
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
+pub(super) struct EventRepositoryOwner {
+    pub login: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub(super) struct EventRefInfo {
     #[serde(alias = "ref")]
     pub commit_ref: String,

--- a/src/drivers/gitlab_driver.rs
+++ b/src/drivers/gitlab_driver.rs
@@ -1,12 +1,14 @@
 use std::env;
 
-use blue_build_utils::constants::{
-    CI_COMMIT_REF_NAME, CI_COMMIT_SHORT_SHA, CI_DEFAULT_BRANCH, CI_MERGE_REQUEST_IID,
-    CI_PIPELINE_SOURCE, CI_PROJECT_NAME, CI_PROJECT_NAMESPACE, CI_PROJECT_URL, CI_REGISTRY,
-    CI_SERVER_HOST, CI_SERVER_PROTOCOL,
+use blue_build_utils::{
+    constants::{
+        CI_COMMIT_REF_NAME, CI_COMMIT_SHORT_SHA, CI_DEFAULT_BRANCH, CI_MERGE_REQUEST_IID,
+        CI_PIPELINE_SOURCE, CI_PROJECT_NAME, CI_PROJECT_NAMESPACE, CI_PROJECT_URL, CI_REGISTRY,
+        CI_SERVER_HOST, CI_SERVER_PROTOCOL,
+    },
+    get_env_var,
 };
 use log::{debug, trace};
-use miette::{Context, IntoDiagnostic};
 
 use crate::drivers::Driver;
 
@@ -24,37 +26,22 @@ impl CiDriver for GitlabDriver {
     fn keyless_cert_identity() -> miette::Result<String> {
         Ok(format!(
             "{}//.gitlab-ci.yml@refs/heads/{}",
-            env::var(CI_DEFAULT_BRANCH)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_DEFAULT_BRANCH}'"))?,
-            env::var(CI_PROJECT_URL)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_PROJECT_URL}'"))?,
+            get_env_var(CI_PROJECT_URL)?,
+            get_env_var(CI_DEFAULT_BRANCH)?,
+        ))
+    }
+
+    fn oidc_provider() -> miette::Result<String> {
+        Ok(format!(
+            "{}://{}",
+            get_env_var(CI_SERVER_PROTOCOL)?,
+            get_env_var(CI_SERVER_HOST)?,
         ))
     }
 
     fn generate_tags(recipe: &blue_build_recipe::Recipe) -> miette::Result<Vec<String>> {
-        let commit_branch = env::var(CI_COMMIT_REF_NAME)
-            .into_diagnostic()
-            .with_context(|| format!("Failed to get '{CI_COMMIT_REF_NAME}'"))?;
-        let commit_sha = env::var(CI_COMMIT_SHORT_SHA)
-            .into_diagnostic()
-            .with_context(|| format!("Failed to get {CI_COMMIT_SHORT_SHA}'"))?;
-        let pipeline_source = env::var(CI_PIPELINE_SOURCE)
-            .into_diagnostic()
-            .with_context(|| format!("Failed to get {CI_PIPELINE_SOURCE}'"))?;
-        trace!("CI_COMMIT_REF_NAME={commit_branch}, CI_COMMIT_SHORT_SHA={commit_sha}, CI_PIPELINE_SOURCE={pipeline_source}");
-
         let mut tags: Vec<String> = Vec::new();
         let os_version = Driver::get_os_version(recipe)?;
-
-        if let Ok(mr_iid) = env::var(CI_MERGE_REQUEST_IID) {
-            trace!("CI_MERGE_REQUEST_IID={mr_iid}");
-            if pipeline_source == "merge_request_event" {
-                debug!("Running in a MR");
-                tags.push(format!("mr-{mr_iid}-{os_version}"));
-            }
-        }
 
         if Self::on_default_branch() {
             debug!("Running on the default branch");
@@ -70,10 +57,26 @@ impl CiDriver for GitlabDriver {
                 tags.push("latest".into());
                 tags.push(timestamp);
             }
+        } else if let Ok(mr_iid) = env::var(CI_MERGE_REQUEST_IID) {
+            trace!("{CI_MERGE_REQUEST_IID}={mr_iid}");
+
+            let pipeline_source = get_env_var(CI_PIPELINE_SOURCE)?;
+            trace!("{CI_PIPELINE_SOURCE}={pipeline_source}");
+
+            if pipeline_source == "merge_request_event" {
+                debug!("Running in a MR");
+                tags.push(format!("mr-{mr_iid}-{os_version}"));
+            }
         } else {
+            let commit_branch = get_env_var(CI_COMMIT_REF_NAME)?;
+            trace!("{CI_COMMIT_REF_NAME}={commit_branch}");
+
             debug!("Running on branch {commit_branch}");
             tags.push(format!("br-{commit_branch}-{os_version}"));
         }
+
+        let commit_sha = get_env_var(CI_COMMIT_SHORT_SHA)?;
+        trace!("{CI_COMMIT_SHORT_SHA}={commit_sha}");
 
         tags.push(format!("{commit_sha}-{os_version}"));
         Ok(tags)
@@ -82,34 +85,206 @@ impl CiDriver for GitlabDriver {
     fn get_repo_url() -> miette::Result<String> {
         Ok(format!(
             "{}://{}/{}/{}",
-            env::var(CI_SERVER_PROTOCOL)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_SERVER_PROTOCOL}'"))?,
-            env::var(CI_SERVER_HOST)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_SERVER_HOST}'"))?,
-            env::var(CI_PROJECT_NAMESPACE)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_PROJECT_NAMESPACE}'"))?,
-            env::var(CI_PROJECT_NAME)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_PROJECT_NAME}'"))?,
+            get_env_var(CI_SERVER_PROTOCOL)?,
+            get_env_var(CI_SERVER_HOST)?,
+            get_env_var(CI_PROJECT_NAMESPACE)?,
+            get_env_var(CI_PROJECT_NAME)?,
         ))
     }
 
     fn get_registry() -> miette::Result<String> {
         Ok(format!(
             "{}/{}/{}",
-            env::var(CI_REGISTRY)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_REGISTRY}'"))?,
-            env::var(CI_PROJECT_NAMESPACE)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_PROJECT_NAMESPACE}'"))?,
-            env::var(CI_PROJECT_NAME)
-                .into_diagnostic()
-                .with_context(|| format!("Failed to get '{CI_PROJECT_NAME}'"))?,
+            get_env_var(CI_REGISTRY)?,
+            get_env_var(CI_PROJECT_NAMESPACE)?,
+            get_env_var(CI_PROJECT_NAME)?,
         )
         .to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::env;
+
+    use blue_build_utils::constants::{
+        CI_COMMIT_REF_NAME, CI_COMMIT_SHORT_SHA, CI_DEFAULT_BRANCH, CI_MERGE_REQUEST_IID,
+        CI_PIPELINE_SOURCE, CI_PROJECT_NAME, CI_PROJECT_NAMESPACE, CI_REGISTRY, CI_SERVER_HOST,
+        CI_SERVER_PROTOCOL,
+    };
+
+    use crate::{
+        drivers::CiDriver,
+        test::{create_test_recipe, BB_UNIT_TEST_MOCK_GET_OS_VERSION, ENV_LOCK},
+    };
+
+    use super::GitlabDriver;
+
+    fn setup_default_branch() {
+        setup();
+        env::set_var(CI_COMMIT_REF_NAME, "main");
+    }
+
+    fn setup_mr_branch() {
+        setup();
+        env::set_var(CI_MERGE_REQUEST_IID, "12");
+        env::set_var(CI_PIPELINE_SOURCE, "merge_request_event");
+        env::set_var(CI_COMMIT_REF_NAME, "test");
+    }
+
+    fn setup_branch() {
+        setup();
+        env::set_var(CI_COMMIT_REF_NAME, "test");
+    }
+
+    fn setup() {
+        env::set_var(CI_DEFAULT_BRANCH, "main");
+        env::set_var(CI_COMMIT_SHORT_SHA, "1234567");
+        env::set_var(CI_REGISTRY, "registry.example.com");
+        env::set_var(CI_PROJECT_NAMESPACE, "test-project");
+        env::set_var(CI_PROJECT_NAME, "test");
+        env::set_var(CI_SERVER_PROTOCOL, "https");
+        env::set_var(CI_SERVER_HOST, "gitlab.example.com");
+        env::set_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION, "");
+    }
+
+    fn teardown() {
+        env::remove_var(CI_REGISTRY);
+        env::remove_var(CI_PROJECT_NAMESPACE);
+        env::remove_var(CI_PROJECT_NAME);
+        env::remove_var(CI_DEFAULT_BRANCH);
+        env::remove_var(CI_COMMIT_REF_NAME);
+        env::remove_var(CI_SERVER_PROTOCOL);
+        env::remove_var(CI_SERVER_HOST);
+        env::remove_var(BB_UNIT_TEST_MOCK_GET_OS_VERSION);
+    }
+
+    #[test]
+    fn get_registry() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        setup();
+
+        let registry = GitlabDriver::get_registry().unwrap();
+
+        assert_eq!(registry, "registry.example.com/test-project/test");
+        teardown();
+    }
+
+    #[test]
+    fn on_default_branch_true() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        setup_default_branch();
+
+        assert!(GitlabDriver::on_default_branch());
+        teardown();
+    }
+
+    #[test]
+    fn on_default_branch_false() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        setup_branch();
+
+        assert!(!GitlabDriver::on_default_branch());
+        teardown();
+    }
+
+    #[test]
+    fn get_repo_url() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        setup();
+
+        let url = GitlabDriver::get_repo_url().unwrap();
+
+        assert_eq!(url, "https://gitlab.example.com/test-project/test");
+        teardown();
+    }
+
+    #[test]
+    fn generate_tags_default_branch() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let timestamp = blue_build_utils::get_tag_timestamp();
+
+        setup_default_branch();
+
+        let mut tags = GitlabDriver::generate_tags(&create_test_recipe()).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec![
+            format!("{timestamp}-40"),
+            "latest".to_string(),
+            timestamp,
+            "1234567-40".to_string(),
+            "40".to_string(),
+        ];
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        teardown();
+    }
+
+    #[test]
+    fn generate_tags_default_branch_alt_tags() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let timestamp = blue_build_utils::get_tag_timestamp();
+
+        setup_default_branch();
+
+        let mut recipe = create_test_recipe();
+
+        recipe.alt_tags = Some(vec!["test-tag1".into(), "test-tag2".into()]);
+
+        let mut tags = GitlabDriver::generate_tags(&recipe).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec![
+            format!("{timestamp}-40"),
+            "1234567-40".to_string(),
+            "40".to_string(),
+        ];
+        expected_tags.extend(recipe.alt_tags.unwrap().iter().map(ToString::to_string));
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        teardown();
+    }
+
+    #[test]
+    fn generate_tags_mr_branch() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        setup_mr_branch();
+
+        let mut tags = GitlabDriver::generate_tags(&create_test_recipe()).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec!["mr-12-40".to_string(), "1234567-40".to_string()];
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        teardown();
+    }
+
+    #[test]
+    fn generate_tags_branch() {
+        let _env = ENV_LOCK.lock().unwrap();
+
+        setup_branch();
+
+        let mut tags = GitlabDriver::generate_tags(&create_test_recipe()).unwrap();
+        tags.sort();
+
+        let mut expected_tags = vec!["1234567-40".to_string(), "br-test-40".to_string()];
+        expected_tags.sort();
+
+        assert_eq!(tags, expected_tags);
+
+        teardown();
     }
 }

--- a/src/drivers/gitlab_driver.rs
+++ b/src/drivers/gitlab_driver.rs
@@ -22,7 +22,7 @@ impl CiDriver for GitlabDriver {
         })
     }
 
-    fn cert_identity() -> miette::Result<String> {
+    fn keyless_cert_identity() -> miette::Result<String> {
         Ok(format!(
             "{}//.gitlab-ci.yml@refs/heads/{}",
             env::var(CI_DEFAULT_BRANCH)

--- a/src/drivers/gitlab_driver.rs
+++ b/src/drivers/gitlab_driver.rs
@@ -1,0 +1,127 @@
+use std::env;
+
+use blue_build_utils::constants::{
+    CI_COMMIT_REF_NAME, CI_COMMIT_SHORT_SHA, CI_DEFAULT_BRANCH, CI_MERGE_REQUEST_IID,
+    CI_PIPELINE_SOURCE, CI_PROJECT_NAME, CI_PROJECT_NAMESPACE, CI_PROJECT_URL, CI_REGISTRY,
+    CI_SERVER_HOST, CI_SERVER_PROTOCOL,
+};
+use chrono::Local;
+use log::{debug, trace};
+use miette::{Context, IntoDiagnostic};
+
+use crate::drivers::Driver;
+
+use super::CiDriver;
+
+pub struct GitlabDriver;
+
+impl CiDriver for GitlabDriver {
+    fn on_main_branch() -> bool {
+        env::var(CI_DEFAULT_BRANCH).is_ok_and(|default_branch| {
+            env::var(CI_COMMIT_REF_NAME).is_ok_and(|branch| default_branch == branch)
+        })
+    }
+
+    fn cert_identity() -> miette::Result<String> {
+        Ok(format!(
+            "{}//.gitlab-ci.yml@refs/heads/{}",
+            env::var(CI_DEFAULT_BRANCH)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_DEFAULT_BRANCH}'"))?,
+            env::var(CI_PROJECT_URL)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_PROJECT_URL}'"))?,
+        ))
+    }
+
+    fn generate_tags<T, S>(
+        recipe: &blue_build_recipe::Recipe,
+        alt_tags: Option<T>,
+    ) -> miette::Result<Vec<String>>
+    where
+        T: AsRef<[S]>,
+        S: AsRef<str>,
+    {
+        let commit_branch = env::var(CI_COMMIT_REF_NAME)
+            .into_diagnostic()
+            .with_context(|| format!("Failed to get '{CI_COMMIT_REF_NAME}'"))?;
+        let default_branch = env::var(CI_DEFAULT_BRANCH)
+            .into_diagnostic()
+            .with_context(|| format!("Failed to get '{CI_DEFAULT_BRANCH}'"))?;
+        let commit_sha = env::var(CI_COMMIT_SHORT_SHA)
+            .into_diagnostic()
+            .with_context(|| format!("Failed to get {CI_COMMIT_SHORT_SHA}'"))?;
+        let pipeline_source = env::var(CI_PIPELINE_SOURCE)
+            .into_diagnostic()
+            .with_context(|| format!("Failed to get {CI_PIPELINE_SOURCE}'"))?;
+        trace!("CI_COMMIT_REF_NAME={commit_branch}, CI_DEFAULT_BRANCH={default_branch},CI_COMMIT_SHORT_SHA={commit_sha}, CI_PIPELINE_SOURCE={pipeline_source}");
+
+        let mut tags: Vec<String> = Vec::new();
+        let os_version = Driver::get_os_version(recipe)?;
+
+        if let Ok(mr_iid) = env::var(CI_MERGE_REQUEST_IID) {
+            trace!("CI_MERGE_REQUEST_IID={mr_iid}");
+            if pipeline_source == "merge_request_event" {
+                debug!("Running in a MR");
+                tags.push(format!("mr-{mr_iid}-{os_version}"));
+            }
+        }
+
+        if default_branch == commit_branch {
+            debug!("Running on the default branch");
+
+            tags.push(os_version.to_string());
+
+            let timestamp = Local::now().format("%Y%m%d").to_string();
+            tags.push(format!("{timestamp}-{os_version}"));
+
+            if let Some(alt_tags) = alt_tags {
+                let alt_tags = alt_tags.as_ref();
+                tags.extend(alt_tags.iter().map(|tag| tag.as_ref().to_string()));
+            } else {
+                tags.push("latest".into());
+                tags.push(timestamp);
+            }
+        } else {
+            debug!("Running on branch {commit_branch}");
+            tags.push(format!("br-{commit_branch}-{os_version}"));
+        }
+
+        tags.push(format!("{commit_sha}-{os_version}"));
+        Ok(tags)
+    }
+
+    fn get_repo_url() -> miette::Result<String> {
+        Ok(format!(
+            "{}://{}/{}/{}",
+            env::var(CI_SERVER_PROTOCOL)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_SERVER_PROTOCOL}'"))?,
+            env::var(CI_SERVER_HOST)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_SERVER_HOST}'"))?,
+            env::var(CI_PROJECT_NAMESPACE)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_PROJECT_NAMESPACE}'"))?,
+            env::var(CI_PROJECT_NAME)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_PROJECT_NAME}'"))?,
+        ))
+    }
+
+    fn get_registry() -> miette::Result<String> {
+        Ok(format!(
+            "{}/{}/{}",
+            env::var(CI_REGISTRY)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_REGISTRY}'"))?,
+            env::var(CI_PROJECT_NAMESPACE)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_PROJECT_NAMESPACE}'"))?,
+            env::var(CI_PROJECT_NAME)
+                .into_diagnostic()
+                .with_context(|| format!("Failed to get '{CI_PROJECT_NAME}'"))?,
+        )
+        .to_lowercase())
+    }
+}

--- a/src/drivers/local_driver.rs
+++ b/src/drivers/local_driver.rs
@@ -1,0 +1,25 @@
+use super::CiDriver;
+
+pub struct LocalDriver;
+
+impl CiDriver for LocalDriver {
+    fn on_default_branch() -> bool {
+        todo!()
+    }
+
+    fn keyless_cert_identity() -> miette::Result<String> {
+        todo!()
+    }
+
+    fn generate_tags(_recipe: &blue_build_recipe::Recipe) -> miette::Result<Vec<String>> {
+        todo!()
+    }
+
+    fn get_repo_url() -> miette::Result<String> {
+        todo!()
+    }
+
+    fn get_registry() -> miette::Result<String> {
+        todo!()
+    }
+}

--- a/src/drivers/local_driver.rs
+++ b/src/drivers/local_driver.rs
@@ -1,25 +1,35 @@
-use super::CiDriver;
+use miette::bail;
+
+use super::{CiDriver, Driver};
 
 pub struct LocalDriver;
 
 impl CiDriver for LocalDriver {
     fn on_default_branch() -> bool {
-        todo!()
+        false
     }
 
     fn keyless_cert_identity() -> miette::Result<String> {
-        todo!()
+        bail!("Keyless not supported");
     }
 
-    fn generate_tags(_recipe: &blue_build_recipe::Recipe) -> miette::Result<Vec<String>> {
-        todo!()
+    fn oidc_provider() -> miette::Result<String> {
+        bail!("Keyless not supported");
+    }
+
+    fn generate_tags(recipe: &blue_build_recipe::Recipe) -> miette::Result<Vec<String>> {
+        Ok(vec![format!("local-{}", Driver::get_os_version(recipe)?)])
+    }
+
+    fn generate_image_name(recipe: &blue_build_recipe::Recipe) -> miette::Result<String> {
+        Ok(recipe.name.trim().to_lowercase())
     }
 
     fn get_repo_url() -> miette::Result<String> {
-        todo!()
+        Ok(String::new())
     }
 
     fn get_registry() -> miette::Result<String> {
-        todo!()
+        Ok(String::new())
     }
 }

--- a/src/drivers/traits.rs
+++ b/src/drivers/traits.rs
@@ -194,7 +194,7 @@ pub trait CiDriver {
     ///
     /// # Errors
     /// Will error if the environment variables aren't set.
-    fn cert_identity() -> Result<String>;
+    fn keyless_cert_identity() -> Result<String>;
 
     /// Generate a list of tags based on the OS version.
     ///

--- a/src/drivers/traits.rs
+++ b/src/drivers/traits.rs
@@ -1,5 +1,6 @@
 use std::process::{ExitStatus, Output};
 
+use blue_build_recipe::Recipe;
 use log::{debug, info, trace};
 use miette::{bail, miette, Result};
 use semver::{Version, VersionReq};
@@ -180,4 +181,62 @@ pub trait SigningDriver {
     /// # Errors
     /// Will error if login fails.
     fn signing_login() -> Result<()>;
+}
+
+/// Allows agnostic retrieval of CI-based information.
+pub trait CiDriver {
+    /// Determines if we're on the main branch of
+    /// a repository.
+    fn on_main_branch() -> bool;
+
+    /// Retrieve the certificate identity for
+    /// keyless signing.
+    ///
+    /// # Errors
+    /// Will error if the environment variables aren't set.
+    fn cert_identity() -> Result<String>;
+
+    /// Generate a list of tags based on the OS version.
+    ///
+    /// ## CI
+    /// The tags are generated based on the CI system that
+    /// is detected. The general format for the default branch is:
+    /// - `${os_version}`
+    /// - `${timestamp}-${os_version}`
+    ///
+    /// On a branch:
+    /// - `br-${branch_name}-${os_version}`
+    ///
+    /// In a PR(GitHub)/MR(GitLab)
+    /// - `pr-${pr_event_number}-${os_version}`/`mr-${mr_iid}-${os_version}`
+    ///
+    /// In all above cases the short git sha is also added:
+    /// - `${commit_sha}-${os_version}`
+    ///
+    /// When `alt_tags` are not present, the following tags are added:
+    /// - `latest`
+    /// - `${timestamp}`
+    ///
+    /// ## Locally
+    /// When ran locally, only a local tag is created:
+    /// - `local-${os_version}`
+    ///
+    /// # Errors
+    /// Will error if the environment variables aren't set.
+    fn generate_tags<T, S>(recipe: &Recipe, alt_tags: Option<T>) -> Result<Vec<String>>
+    where
+        T: AsRef<[S]>,
+        S: AsRef<str>;
+
+    /// Get the URL for the repository.
+    ///
+    /// # Errors
+    /// Will error if the environment variables aren't set.
+    fn get_repo_url() -> Result<String>;
+
+    /// Get the registry ref for the image.
+    ///
+    /// # Errors
+    /// Will error if the environment variables aren't set.
+    fn get_registry() -> Result<String>;
 }

--- a/src/drivers/traits.rs
+++ b/src/drivers/traits.rs
@@ -187,7 +187,7 @@ pub trait SigningDriver {
 pub trait CiDriver {
     /// Determines if we're on the main branch of
     /// a repository.
-    fn on_main_branch() -> bool;
+    fn on_default_branch() -> bool;
 
     /// Retrieve the certificate identity for
     /// keyless signing.
@@ -223,10 +223,7 @@ pub trait CiDriver {
     ///
     /// # Errors
     /// Will error if the environment variables aren't set.
-    fn generate_tags<T, S>(recipe: &Recipe, alt_tags: Option<T>) -> Result<Vec<String>>
-    where
-        T: AsRef<[S]>,
-        S: AsRef<str>;
+    fn generate_tags(recipe: &Recipe) -> Result<Vec<String>>;
 
     /// Get the URL for the repository.
     ///

--- a/src/drivers/traits.rs
+++ b/src/drivers/traits.rs
@@ -196,6 +196,12 @@ pub trait CiDriver {
     /// Will error if the environment variables aren't set.
     fn keyless_cert_identity() -> Result<String>;
 
+    /// Retrieve the OIDC Provider for keyless signing.
+    ///
+    /// # Errors
+    /// Will error if the environment variables aren't set.
+    fn oidc_provider() -> Result<String>;
+
     /// Generate a list of tags based on the OS version.
     ///
     /// ## CI
@@ -224,6 +230,18 @@ pub trait CiDriver {
     /// # Errors
     /// Will error if the environment variables aren't set.
     fn generate_tags(recipe: &Recipe) -> Result<Vec<String>>;
+
+    /// Generates the image name based on CI.
+    ///
+    /// # Errors
+    /// Will error if the environment variables aren't set.
+    fn generate_image_name(recipe: &Recipe) -> Result<String> {
+        Ok(format!(
+            "{}/{}",
+            Self::get_registry()?,
+            recipe.name.trim().to_lowercase()
+        ))
+    }
 
     /// Get the URL for the repository.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,40 @@ pub mod credentials;
 pub mod drivers;
 pub mod image_metadata;
 pub mod rpm_ostree_status;
+
+#[cfg(test)]
+pub(crate) mod test {
+    use std::sync::Mutex;
+
+    use blue_build_recipe::{Module, ModuleExt, Recipe};
+    use indexmap::IndexMap;
+    use once_cell::sync::Lazy;
+
+    pub const BB_UNIT_TEST_MOCK_GET_OS_VERSION: &str = "BB_UNIT_TEST_MOCK_GET_OS_VERSION";
+
+    /// This mutex is used for tests that require the reading of
+    /// environment variables. Env vars are an inheritly unsafe
+    /// as they can be changed and affect other threads functionality.
+    ///
+    /// For tests that require setting env vars, they need to lock this
+    /// mutex before making changes to the env. Any changes made to the env
+    /// MUST be undone in the same test before dropping the lock. Failure to
+    /// do so will cause unpredictable behavior with other tests.
+    pub static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    pub fn create_test_recipe() -> Recipe<'static> {
+        Recipe::builder()
+            .name("test")
+            .description("This is a test")
+            .base_image("base-image")
+            .image_version("40")
+            .modules_ext(
+                ModuleExt::builder()
+                    .modules(vec![Module::builder().build()])
+                    .build(),
+            )
+            .stages_ext(None)
+            .extra(IndexMap::new())
+            .build()
+    }
+}

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -1,10 +1,8 @@
-use std::{borrow::Cow, env, fs, path::Path, process};
+use std::{borrow::Cow, fs, path::Path, process};
 
 use blue_build_recipe::Recipe;
 use blue_build_utils::constants::{
-    CI_PROJECT_NAME, CI_PROJECT_NAMESPACE, CI_SERVER_HOST, CI_SERVER_PROTOCOL, CONFIG_PATH,
-    CONTAINERFILES_PATH, CONTAINER_FILE, COSIGN_PUB_PATH, FILES_PATH, GITHUB_RESPOSITORY,
-    GITHUB_SERVER_URL,
+    CONFIG_PATH, CONTAINERFILES_PATH, CONTAINER_FILE, COSIGN_PUB_PATH, FILES_PATH,
 };
 use log::{debug, error, trace, warn};
 use typed_builder::TypedBuilder;
@@ -30,6 +28,9 @@ pub struct ContainerFileTemplate<'a> {
 
     #[builder(setter(into))]
     exports_tag: Cow<'a, str>,
+
+    #[builder(setter(into))]
+    repo: Cow<'a, str>,
 }
 
 #[derive(Debug, Clone, Template, TypedBuilder)]
@@ -121,38 +122,6 @@ fn print_containerfile(containerfile: &str) -> String {
     debug!("Containerfile contents {}:\n{file}", path.display());
 
     file
-}
-
-fn get_repo_url() -> Option<String> {
-    Some(
-        match (
-            // GitHub vars
-            env::var(GITHUB_SERVER_URL),
-            env::var(GITHUB_RESPOSITORY),
-            // GitLab vars
-            env::var(CI_SERVER_PROTOCOL),
-            env::var(CI_SERVER_HOST),
-            env::var(CI_PROJECT_NAMESPACE),
-            env::var(CI_PROJECT_NAME),
-        ) {
-            (Ok(github_server), Ok(github_repo), _, _, _, _) => {
-                format!("{github_server}/{github_repo}")
-            }
-            (
-                _,
-                _,
-                Ok(ci_server_protocol),
-                Ok(ci_server_host),
-                Ok(ci_project_namespace),
-                Ok(ci_project_name),
-            ) => {
-                format!(
-                    "{ci_server_protocol}://{ci_server_host}/{ci_project_namespace}/{ci_project_name}"
-                )
-            }
-            _ => return None,
-        },
-    )
 }
 
 fn modules_exists() -> bool {

--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -36,7 +36,5 @@ RUN rm -fr /tmp/* /var/* && ostree container commit
 LABEL {{ blue_build_utils::constants::BUILD_ID_LABEL }}="{{ build_id }}"
 LABEL org.opencontainers.image.title="{{ recipe.name }}"
 LABEL org.opencontainers.image.description="{{ recipe.description }}"
-{%- if let Some(repo) = self::get_repo_url() %}
 LABEL org.opencontainers.image.source="{{ repo }}"
-{%- endif %}
 LABEL io.artifacthub.package.readme-url=https://raw.githubusercontent.com/blue-build/cli/main/README.md

--- a/test-files/github-events/branch.json
+++ b/test-files/github-events/branch.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/test-branch",
+  "repository": {
+    "default_branch": "main",
+    "owner": {
+      "login": "test-owner"
+    },
+    "html_url": "https://example.com/"
+  }
+}

--- a/test-files/github-events/default-branch.json
+++ b/test-files/github-events/default-branch.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/main",
+  "repository": {
+    "default_branch": "main",
+    "owner": {
+      "login": "test-owner"
+    },
+    "html_url": "https://example.com/"
+  }
+}

--- a/test-files/github-events/pr-branch.json
+++ b/test-files/github-events/pr-branch.json
@@ -1,0 +1,15 @@
+{
+  "head": {
+    "ref": "test-branch"
+  },
+  "base": {
+    "ref": "main"
+  },
+  "repository": {
+    "default_branch": "main",
+    "owner": {
+      "login": "test-owner"
+    },
+    "html_url": "https://example.com/"
+  }
+}

--- a/utils/src/constants.rs
+++ b/utils/src/constants.rs
@@ -37,6 +37,7 @@ pub const SIGSTORE_ID_TOKEN: &str = "SIGSTORE_ID_TOKEN";
 pub const GITHUB_ACTIONS: &str = "GITHUB_ACTIONS";
 pub const GITHUB_ACTOR: &str = "GITHUB_ACTOR";
 pub const GITHUB_EVENT_NAME: &str = "GITHUB_EVENT_NAME";
+pub const GITHUB_EVENT_PATH: &str = "GITHUB_EVENT_PATH";
 pub const GITHUB_REF_NAME: &str = "GITHUB_REF_NAME";
 pub const GITHUB_RESPOSITORY: &str = "GITHUB_REPOSITORY";
 pub const GITHUB_REPOSITORY_OWNER: &str = "GITHUB_REPOSITORY_OWNER";
@@ -60,6 +61,7 @@ pub const CI_SERVER_PROTOCOL: &str = "CI_SERVER_PROTOCOL";
 pub const CI_REGISTRY: &str = "CI_REGISTRY";
 pub const CI_REGISTRY_PASSWORD: &str = "CI_REGISTRY_PASSWORD";
 pub const CI_REGISTRY_USER: &str = "CI_REGISTRY_USER";
+pub const GITLAB_CI: &str = "GITLAB_CI";
 
 // Terminal vars
 pub const TERM_PROGRAM: &str = "TERM_PROGRAM";

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -20,7 +20,7 @@ use blake2::{
 use chrono::Local;
 use format_serde_error::SerdeError;
 use log::trace;
-use miette::{miette, IntoDiagnostic, Result};
+use miette::{miette, Context, IntoDiagnostic, Result};
 
 use crate::constants::CONTAINER_FILE;
 
@@ -115,4 +115,14 @@ pub fn generate_containerfile_path<T: AsRef<Path>>(path: T) -> Result<PathBuf> {
 #[must_use]
 pub fn get_tag_timestamp() -> String {
     Local::now().format("%Y%m%d").to_string()
+}
+
+/// Get's the env var wrapping it with a miette error
+///
+/// # Errors
+/// Will error if the env var doesn't exist.
+pub fn get_env_var(key: &str) -> Result<String> {
+    std::env::var(key)
+        .into_diagnostic()
+        .with_context(|| format!("Failed to get {key}'"))
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -17,6 +17,7 @@ use blake2::{
     digest::{Update, VariableOutput},
     Blake2bVar,
 };
+use chrono::Local;
 use format_serde_error::SerdeError;
 use log::trace;
 use miette::{miette, IntoDiagnostic, Result};
@@ -109,4 +110,9 @@ pub fn generate_containerfile_path<T: AsRef<Path>>(path: T) -> Result<PathBuf> {
         "{CONTAINER_FILE}.{}",
         BASE64_URL_SAFE_NO_PAD.encode(buf)
     )))
+}
+
+#[must_use]
+pub fn get_tag_timestamp() -> String {
+    Local::now().format("%Y%m%d").to_string()
 }


### PR DESCRIPTION
Creating a CI Driver that allows us to separate out logic for the various CI systems. This will allow easier extensibility when adding more implementations later. 