### PR TITLE
fix: add typespec schemas for cli modules, remove modules.json (not needed anymore)

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,4 +1,0 @@
-[
-  "https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/containerfile/module.yml",
-  "https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/copy/module.yml"
-]

--- a/template/templates/modules/containerfile/containerfile.tsp
+++ b/template/templates/modules/containerfile/containerfile.tsp
@@ -1,0 +1,16 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/containerfile.json")
+model ContainerfileModule {
+    /** The containerfile module is a tool for adding custom Containerfile instructions for custom image builds. 
+     * https://blue-build.org/reference/modules/containerfile/
+     */
+    type: "containerfile";
+
+    /** Lines to directly insert into the generated Containerfile. */
+    snippets?: Array<string>;
+
+    /** Names of directories in ./containerfiles/ containing each a Containerfile to insert into the generated Containerfile. */
+    containerfiles?: Array<string>;
+}

--- a/template/templates/modules/containerfile/module.yml
+++ b/template/templates/modules/containerfile/module.yml
@@ -1,6 +1,5 @@
 name: containerfile
 shortdesc: The containerfile module enables the addition of custom Containerfile instructions into the build process.
-readme: https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/containerfile/README.md
 example: |
   type: containerfile
   snippets:

--- a/template/templates/modules/copy/README.md
+++ b/template/templates/modules/copy/README.md
@@ -15,7 +15,7 @@ The `copy` module is a short-hand method of adding a [`COPY`](https://docs.docke
 The `copy` module's properties are a 1-1 match with the `COPY` instruction containing `src`, `dest`, and `from` (optional). The example below will `COPY` the file `/usr/bin/yq` from `docker.io/mikefarah/yq` into `/usr/bin/`.
 
 ```yaml
-mdoules:
+modules:
 - type: copy
   from: docker.io/mikefarah/yq
   src: /usr/bin/yq
@@ -31,7 +31,7 @@ COPY --linked --from=docker.io/mikefarah/yq /usr/bin/yq /usr/bin/
 Omitting `from:` will allow copying from the build context:
 
 ```yaml
-mdoules:
+modules:
 - type: copy
   src: file/to/copy.conf
   dest: /usr/etc/app/

--- a/template/templates/modules/copy/copy.tsp
+++ b/template/templates/modules/copy/copy.tsp
@@ -11,11 +11,11 @@ model CopyModule {
     /** Equivalent to the --from property in a COPY statement, use to specify an image to copy from.
      * By default, the COPY source is the build environment's file tree.
      */
-    from?: string,
+    from?: string;
 
     /** Path to source file or directory. */
-    src: string,
+    src: string;
 
     /** Path to destination file or directory. */
-    dest: string,
+    dest: string;
 }

--- a/template/templates/modules/copy/copy.tsp
+++ b/template/templates/modules/copy/copy.tsp
@@ -1,0 +1,21 @@
+import "@typespec/json-schema";
+using TypeSpec.JsonSchema;
+
+@jsonSchema("/modules/copy.json")
+model CopyModule {
+    /** The copy module is a short-hand method of adding a COPY instruction into the Containerfile.
+     * https://blue-build.org/reference/modules/copy/
+     */
+    type: "containerfile";
+
+    /** Equivalent to the --from property in a COPY statement, use to specify an image to copy from.
+     * By default, the COPY source is the build environment's file tree.
+     */
+    from?: string,
+
+    /** Path to source file or directory. */
+    src: string,
+
+    /** Path to destination file or directory. */
+    dest: string,
+}

--- a/template/templates/modules/copy/module.yml
+++ b/template/templates/modules/copy/module.yml
@@ -1,6 +1,5 @@
 name: copy
 shortdesc: The copy module is a direct translation of the `COPY` instruction in a Containerfile.
-readme: https://raw.githubusercontent.com/blue-build/cli/main/template/templates/modules/copy/README.md
 example: |
   type: copy
   from: docker.io/mikefarah/yq


### PR DESCRIPTION
The website build process now uses the GitHub API to generate a global `modules.json`. If you decide to move the directory containing all the modules, please tell me, or make a PR changing [this line](https://github.com/blue-build/website/blob/9eb198c4e532e82e70b980da955b87f39ce663b4/astro.config.mjs#L102). If you don't, I'll find out anyways, because the website builds will break. 

Also, whenever updating the modules, make sure the schema is updated too to match the current state of the module. If you need help with writing [TypeSpec](https://typespec.io/), consult me, but you probably wont, since it's just a type system kind of like TypeScript's or Rust's .