### PR TITLE
chore: Move files from `/usr/etc/` to `/etc/` in build-time

### DIFF
--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -18,8 +18,8 @@ ARG BASE_IMAGE="{{ recipe.base_image }}"
 
 # Key RUN
 RUN --mount=type=bind,from=stage-keys,src=/keys,dst=/tmp/keys \
-  mkdir -p /usr/etc/pki/containers/ \
-  && cp /tmp/keys/* /usr/etc/pki/containers/ \
+  mkdir -p /etc/pki/containers/ \
+  && cp /tmp/keys/* /etc/pki/containers/ \
   && ostree container commit
 
 # Bin RUN


### PR DESCRIPTION
Take a look at this issue for more details:

https://github.com/blue-build/modules/issues/314

Idk if anything else needs to be done, please tell

Should be tested for regressions too