### PR TITLE
chore: Migrate script module name to scripts

### DIFF
--- a/recipe/src/stage.rs
+++ b/recipe/src/stage.rs
@@ -78,7 +78,7 @@ pub struct Stage<'a> {
     /// - name: hello-world
     ///   image: alpine
     ///   modules:
-    ///   - type: script
+    ///   - type: scripts
     ///     snippets:
     ///     - echo "Hello World!"
     /// ```


### PR DESCRIPTION
Only fixed the comment in code,

idk if something else should be done in order to support both `script` & `scripts` module name in stages

Parent PR:
https://github.com/blue-build/modules/pull/334