### PR TITLE
fix: switch cosign registry from GCR to GHCR

### DIFF
--- a/utils/src/constants.rs
+++ b/utils/src/constants.rs
@@ -72,7 +72,7 @@ pub const LC_TERMINAL_VERSION: &str = "LC_TERMINAL_VERSION";
 pub const XDG_RUNTIME_DIR: &str = "XDG_RUNTIME_DIR";
 
 // Misc
-pub const COSIGN_IMAGE: &str = "gcr.io/projectsigstore/cosign:latest";
+pub const COSIGN_IMAGE: &str = "ghcr.io/sigstore/cosign/cosign:latest";
 pub const OCI_ARCHIVE: &str = "oci-archive";
 pub const OSTREE_IMAGE_SIGNED: &str = "ostree-image-signed";
 pub const OSTREE_UNVERIFIED_IMAGE: &str = "ostree-unverified-image";


### PR DESCRIPTION
This changes the Dockerfile to pull the cosign container image from GHCR instead of Google Cloud. This helps the Sigstore team manage their cloud spend (as GHCR is provided for free and Google Cloud Artifact Registry is not).

Note the container hash does not change and images are posted to both locations upon cosign's release process.