### PR TITLE
chore: Remove unneded comment about `bootupctl` command

### DIFF
--- a/scripts/post_build.sh
+++ b/scripts/post_build.sh
@@ -2,13 +2,5 @@
 
 set -euo pipefail
 
-# See issue https://github.com/coreos/bootupd/issues/635
-# if command -v bootupctl && [ -f /usr/lib/ostree-boot/efi/EFI ] && [ "$OS_VERSION" -ge "40" ]; then
-#   echo "Generating update metadata"
-#   bootupctl backend generate-update-metadata
-# else
-#   echo "Program bootupctl not installed or EFI file not available, skipping..."
-# fi
-
-rm -fr /tmp/* /var/*
+rm -rf /tmp/* /var/*
 ostree container commit


### PR DESCRIPTION
Not needed to be done anymore, as it's done upstream.

So removing the comment.