### PR TITLE
fix: Add logic for inspecting multi-manifest images

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -124,6 +124,15 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
 
+      - name: Earthly login
+        env:
+          EARTHLY_SAT_TOKEN: ${{ secrets.EARTHLY_SAT_TOKEN }}
+        if: env.EARTHLY_SAT_TOKEN != null
+        run: |
+          earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
+          earthly org s blue-build
+          earthly sat s pr
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
         run: |
           earthly account login --token ${{ secrets.EARTHLY_SAT_TOKEN }} >> /dev/null
           earthly org s blue-build
-          earthly sat s pr
+          earthly sat s main
 
       - uses: actions/checkout@v4
         with:

--- a/integration-tests/Earthfile
+++ b/integration-tests/Earthfile
@@ -84,7 +84,7 @@ validate:
     FROM +test-base
 
     RUN --no-cache bluebuild -v validate recipes/recipe.yml
-    RUN --no-cache bluebuild -v validate recipes/recipe-39.yml
+    RUN --no-cache bluebuild -v validate recipes/recipe-gts.yml
     RUN --no-cache bluebuild -v validate recipes/recipe-arm64.yml
     RUN --no-cache bluebuild -v validate recipes/recipe-invalid.yml && exit 1 || exit 0
     RUN --no-cache bluebuild -v validate recipes/recipe-invalid-module.yml && exit 1 || exit 0

--- a/process/drivers/docker_driver/metadata.rs
+++ b/process/drivers/docker_driver/metadata.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+
+use miette::{bail, Report};
+use serde::Deserialize;
+
+use crate::drivers::types::{ImageMetadata, Platform};
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Metadata {
+    manifest: Manifest,
+    image: MetadataImage,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct PlatformManifest {
+    digest: String,
+    platform: PlatformManifestInfo,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct PlatformManifestInfo {
+    architecture: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Manifest {
+    digest: String,
+
+    #[serde(default)]
+    manifests: Vec<PlatformManifest>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct MetadataPlatformImage {
+    config: Config,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum MetadataImage {
+    Single(MetadataPlatformImage),
+    Multi(HashMap<String, MetadataPlatformImage>),
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct Config {
+    labels: HashMap<String, serde_json::Value>,
+}
+
+impl TryFrom<(Metadata, Platform)> for ImageMetadata {
+    type Error = Report;
+
+    fn try_from((metadata, platform): (Metadata, Platform)) -> Result<Self, Self::Error> {
+        match metadata.image {
+            MetadataImage::Single(image) => Ok(Self {
+                labels: image.config.labels,
+                digest: metadata.manifest.digest,
+            }),
+            MetadataImage::Multi(mut platforms) => {
+                let Some(image) = platforms.remove(&platform.to_string()) else {
+                    bail!("Image information does not exist for {platform}");
+                };
+                let Some(manifest) = metadata
+                    .manifest
+                    .manifests
+                    .into_iter()
+                    .find(|manifest| manifest.platform.architecture == platform.arch())
+                else {
+                    bail!("Manifest does not exist for {platform}");
+                };
+                Ok(Self {
+                    labels: image.config.labels,
+                    digest: manifest.digest,
+                })
+            }
+        }
+    }
+}

--- a/process/drivers/types.rs
+++ b/process/drivers/types.rs
@@ -185,9 +185,13 @@ pub enum Platform {
 impl Platform {
     /// The architecture of the platform.
     #[must_use]
-    pub const fn arch(&self) -> &str {
+    pub fn arch(&self) -> &str {
         match *self {
-            Self::Native => "native",
+            Self::Native => match std::env::consts::ARCH {
+                "x86_64" => "amd64",
+                "aarch64" => "arm64",
+                arch => unimplemented!("Arch {arch} is unsupported"),
+            },
             Self::LinuxAmd64 => "amd64",
             Self::LinuxArm64 => "arm64",
         }
@@ -200,7 +204,11 @@ impl std::fmt::Display for Platform {
             f,
             "{}",
             match *self {
-                Self::Native => "native",
+                Self::Native => match std::env::consts::ARCH {
+                    "x86_64" => "linux/amd64",
+                    "aarch64" => "linux/arm64",
+                    arch => unimplemented!("Arch {arch} is unsupported"),
+                },
                 Self::LinuxAmd64 => "linux/amd64",
                 Self::LinuxArm64 => "linux/arm64",
             }


### PR DESCRIPTION
This is blocking https://github.com/blue-build/modules/issues/364 and #261  as we need a patch to go out but, multi-arch inspection was not setup correctly. I forgot to actually build `arm` and `amd` versions of our images, and after getting that working, image inspections started to fail. This PR will allow inspecting multi-arch images.