### PR TITLE
chore: Copy signing keys to `/etc/` only

### DIFF
--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -30,7 +30,8 @@ modules:
       - firefox-langpacks
 
   - type: signing
-
+    source: ghcr.io/blue-build/modules:signing-switch-fully-to-etc
+    
   - type: test-module
     source: local
 

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -30,7 +30,6 @@ modules:
       - firefox-langpacks
 
   - type: signing
-    source: ghcr.io/blue-build/modules:signing-switch-fully-to-etc
     
   - type: test-module
     source: local

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -30,7 +30,7 @@ modules:
       - firefox-langpacks
 
   - type: signing
-    
+
   - type: test-module
     source: local
 

--- a/template/templates/Containerfile.j2
+++ b/template/templates/Containerfile.j2
@@ -26,9 +26,7 @@ ARG RUST_LOG_STYLE=always
 # Key RUN
 RUN --mount=type=bind,from=stage-keys,src=/keys,dst=/tmp/keys \
   mkdir -p /etc/pki/containers/ \
-  mkdir -p /usr/etc/pki/containers/ \
   && cp /tmp/keys/* /etc/pki/containers/ \
-  && cp /tmp/keys/* /usr/etc/pki/containers/ \
   && ostree container commit
 
 # Bin RUN


### PR DESCRIPTION
Supplements main PR: https://github.com/blue-build/modules/pull/375

Tests & it works, can be merged.