### PR TITLE
chore: Use consistent syntax for getting information from os-release

### DIFF
--- a/process/drivers.rs
+++ b/process/drivers.rs
@@ -282,7 +282,7 @@ fn get_version_run_image(oci_ref: &Reference) -> Result<u64> {
             .args(bon::vec![
                 "/bin/bash",
                 "-c",
-                "grep -Po '(?<=VERSION_ID=)\\d+' /usr/lib/os-release",
+                r#"awk -F= '/^VERSION_ID=/ {gsub(/"/, "", $2); print $2}' /usr/lib/os-release"#,
             ])
             .pull(true)
             .remove(true)

--- a/scripts/exports.sh
+++ b/scripts/exports.sh
@@ -45,7 +45,7 @@ color_string() {
 }
 
 # Parse OS version and export it
-export OS_VERSION="$(grep -Po "(?<=VERSION_ID=)\d+" /usr/lib/os-release)"
+export OS_VERSION="$(awk -F= '/^VERSION_ID=/ {gsub(/"/, "", $2); print $2}' /usr/lib/os-release)"
 export OS_ARCH="$(uname -m)"
 
 # Export functions for use in sub-shells or sourced scripts

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -f /etc/os-release ]; then
-  export ID="$(cat /etc/os-release | grep -E '^ID=' | awk -F '=' '{print $2}')"
+  export ID="$(awk -F= '/^ID=/ {gsub(/"/, "", $2); print $2}' /etc/os-release)"
 
   if [ "$ID" = "alpine" ]; then
     echo "Setting up Alpine based image to run BlueBuild modules"


### PR DESCRIPTION
This will make it work for Ubuntu versions, where it's `24.04` or similar. Or if some distros use letters for VERSION_IDs.

Please tell me if I escaped quotes correctly in `drivers.rs`