### PR TITLE
feat: Allow fresh rechunking of image

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -296,6 +296,7 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
         run: |
           export CARGO_HOME=$HOME/.cargo
+          just test-fresh-rechunk-build
           just test-rechunk-build
 
   arm64-build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,10 +333,9 @@ jobs:
           GH_PR_EVENT_NUMBER: ${{ github.event.number }}
           COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
         run: |
-          just install-debug-all-features
-          cd integration-tests/test-repo
           export CARGO_HOME=$HOME/.cargo
-          sudo -E $CARGO_HOME/bin/bluebuild build --push -vv --rechunk recipes/recipe-rechunk.yml
+          just test-fresh-rechunk-build
+          just test-rechunk-build
 
   arm64-build:
     timeout-minutes: 40

--- a/justfile
+++ b/justfile
@@ -155,6 +155,15 @@ test-rechunk-build: install-debug-all-features
     --rechunk \
     recipes/recipe-rechunk.yml
 
+test-fresh-rechunk-build: install-debug-all-features
+  cd integration-tests/test-repo \
+  && sudo -E {{ cargo_bin }}/bluebuild build \
+    {{ should_push }} \
+    -vv \
+    --rechunk \
+    --rechunk-clear-plan \
+    recipes/recipe-rechunk.yml
+
 # Run arm integration test
 test-arm64-build: install-debug-all-features
   cd integration-tests/test-repo \

--- a/process/drivers/opts/rechunk.rs
+++ b/process/drivers/opts/rechunk.rs
@@ -45,4 +45,7 @@ pub struct RechunkOpts<'scope> {
     #[builder(default)]
     pub compression: CompressionType,
     pub tempdir: Option<&'scope Path>,
+
+    #[builder(default)]
+    pub clear_plan: bool,
 }

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -442,7 +442,7 @@ pub trait RechunkDriver: RunDriver + BuildDriver + ContainerMountDriver {
                 "REPO" => "/var/ostree/repo",
                 "PREV_REF" => &*opts.image,
                 "OUT_NAME" => ostree_cache_id,
-                // "PREV_REF_FAIL" => "true",
+                "CLEAR_PLAN" => if opts.clear_plan { "true" } else { "" },
                 "VERSION" => format!("{}", opts.version),
                 "OUT_REF" => format!("oci:{ostree_cache_id}"),
                 "GIT_DIR" => "/var/git",

--- a/utils/src/constants.rs
+++ b/utils/src/constants.rs
@@ -22,6 +22,8 @@ pub const BB_PRIVATE_KEY: &str = "BB_PRIVATE_KEY";
 pub const BB_REGISTRY: &str = "BB_REGISTRY";
 pub const BB_REGISTRY_NAMESPACE: &str = "BB_REGISTRY_NAMESPACE";
 pub const BB_USERNAME: &str = "BB_USERNAME";
+pub const BB_BUILD_RECHUNK: &str = "BB_BUILD_RECHUNK";
+pub const BB_BUILD_RECHUNK_CLEAR_PLAN: &str = "BB_BUILD_RECHUNK_CLEAR_PLAN";
 
 // Docker vars
 pub const DOCKER_HOST: &str = "DOCKER_HOST";


### PR DESCRIPTION
I've noticed some strangeness when it comes to using rechunk on a image that is based off of a rechunked image. Mostly my initramfs is being truncated and not being loaded on boot, so this is an attempt to enable the use of fresh rechunking by not supplying the previous ref of the image.