### PR TITLE
chore: Retain cache for `rpm-ostree` & `dnf` post build

### DIFF
--- a/scripts/post_build.sh
+++ b/scripts/post_build.sh
@@ -2,5 +2,7 @@
 
 set -euo pipefail
 
-rm -rf /tmp/* /var/*
+rm -rf /tmp/* || true
+find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
+find /var/cache/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
 ostree container commit


### PR DESCRIPTION
Just mimicking what Bluefin does here:

https://github.com/ublue-os/bluefin/blob/main/build_files/shared/clean-stage.sh

I'm not sure why they keep the cache from `rpm-ostree` & `dnf5`, but I just figured to make a PR, as it's easy to do.