### PR TITLE
fix: pull akmods-extra only for bazzite (Fixes #441)

### DIFF
--- a/recipe/src/akmods_info.rs
+++ b/recipe/src/akmods_info.rs
@@ -3,7 +3,7 @@ use bon::Builder;
 #[derive(Debug, Clone, Builder, PartialEq, Eq, Hash)]
 pub struct AkmodsInfo {
     #[builder(into)]
-    pub images: (String, String, Option<String>),
+    pub images: (String, Option<String>, Option<String>),
 
     #[builder(into)]
     pub stage_name: String,

--- a/recipe/src/module.rs
+++ b/recipe/src/module.rs
@@ -154,34 +154,43 @@ impl<'a> ModuleRequiredFields<'a> {
 
         AkmodsInfo::builder()
             .images(match (base, nvidia) {
-                (Some(b), NvidiaAkmods::Enabled | NvidiaAkmods::Proprietary) if !b.is_empty() => (
-                    format!("akmods:{b}-{os_version}"),
-                    format!("akmods-extra:{b}-{os_version}"),
-                    Some(format!("akmods-nvidia:{b}-{os_version}")),
+                (Some("bazzite"), NvidiaAkmods::Enabled | NvidiaAkmods::Proprietary) => (
+                    format!("akmods:bazzite-{os_version}"),
+                    Some(format!("akmods-extra:bazzite-{os_version}")),
+                    Some(format!("akmods-nvidia:bazzite-{os_version}")),
                 ),
-                (Some(b), NvidiaAkmods::Disabled) if !b.is_empty() => (
-                    format!("akmods:{b}-{os_version}"),
-                    format!("akmods-extra:{b}-{os_version}"),
+                (Some("bazzite"), NvidiaAkmods::Disabled) => (
+                    format!("akmods:bazzite-{os_version}"),
+                    Some(format!("akmods-extra:bazzite-{os_version}")),
                     None,
                 ),
+                (Some("bazzite"), NvidiaAkmods::Open) => (
+                    format!("akmods:bazzite-{os_version}"),
+                    Some(format!("akmods-extra:bazzite-{os_version}")),
+                    Some(format!("akmods-nvidia-open:bazzite-{os_version}")),
+                ),
+                (Some(b), NvidiaAkmods::Enabled | NvidiaAkmods::Proprietary) if !b.is_empty() => (
+                    format!("akmods:{b}-{os_version}"),
+                    None,
+                    Some(format!("akmods-nvidia:{b}-{os_version}")),
+                ),
+                (Some(b), NvidiaAkmods::Disabled) if !b.is_empty() => {
+                    (format!("akmods:{b}-{os_version}"), None, None)
+                }
                 (Some(b), NvidiaAkmods::Open) if !b.is_empty() => (
                     format!("akmods:{b}-{os_version}"),
-                    format!("akmods-extra:{b}-{os_version}"),
+                    None,
                     Some(format!("akmods-nvidia-open:{b}-{os_version}")),
                 ),
                 (_, NvidiaAkmods::Enabled | NvidiaAkmods::Proprietary) => (
                     format!("akmods:main-{os_version}"),
-                    format!("akmods-extra:main-{os_version}"),
+                    None,
                     Some(format!("akmods-nvidia:main-{os_version}")),
                 ),
-                (_, NvidiaAkmods::Disabled) => (
-                    format!("akmods:main-{os_version}"),
-                    format!("akmods-extra:main-{os_version}"),
-                    None,
-                ),
+                (_, NvidiaAkmods::Disabled) => (format!("akmods:main-{os_version}"), None, None),
                 (_, NvidiaAkmods::Open) => (
                     format!("akmods:main-{os_version}"),
-                    format!("akmods-extra:main-{os_version}"),
+                    None,
                     Some(format!("akmods-nvidia-open:main-{os_version}")),
                 ),
             })

--- a/template/templates/modules/akmods/akmods.j2
+++ b/template/templates/modules/akmods/akmods.j2
@@ -2,7 +2,9 @@
 # Stage for AKmod {{ info.stage_name }}
 FROM scratch as stage-akmods-{{ info.stage_name }}
 COPY --from=ghcr.io/ublue-os/{{ info.images.0 }} /rpms /rpms
-COPY --from=ghcr.io/ublue-os/{{ info.images.1 }} /rpms /rpms
+  {%- if let Some(extra_image) = info.images.1 %}
+COPY --from=ghcr.io/ublue-os/{{ extra_image }} /rpms /rpms
+  {%- endif %}
   {%- if let Some(nv_image) = info.images.2 %}
 COPY --from=ghcr.io/ublue-os/{{ nv_image }} /rpms /rpms
   {%- endif %}


### PR DESCRIPTION
When using fedora 42 with the main images, the build will fail due to the non-existing akmods-extra images.
It looks like, these images will only exist for the `bazzite` based ones.