### PR TITLE
feat: Add all linux platforms

### DIFF
--- a/process/drivers.rs
+++ b/process/drivers.rs
@@ -188,9 +188,9 @@ impl Driver {
     pub fn get_os_version(
         /// The OCI image reference.
         oci_ref: &Reference,
+
         /// The platform of the image to pull the version info from.
-        #[builder(default)]
-        platform: Platform,
+        platform: Option<Platform>,
     ) -> Result<u64> {
         trace!("Driver::get_os_version({oci_ref:#?})");
 
@@ -208,7 +208,7 @@ impl Driver {
         let os_version = Self::get_metadata(
             &GetMetadataOpts::builder()
                 .image(oci_ref)
-                .platform(platform)
+                .maybe_platform(platform)
                 .build(),
         )
         .and_then(|inspection| {

--- a/process/drivers/buildah_driver.rs
+++ b/process/drivers/buildah_driver.rs
@@ -8,7 +8,7 @@ use miette::{Context, IntoDiagnostic, Result, bail, miette};
 use serde::Deserialize;
 use tempfile::TempDir;
 
-use crate::{drivers::types::Platform, logging::CommandLogging};
+use crate::logging::CommandLogging;
 
 use super::{
     BuildDriver, DriverVersion,
@@ -60,9 +60,9 @@ impl BuildDriver for BuildahDriver {
             "build",
             for opts.secrets.args(&temp_dir)?,
             if opts.secrets.ssh() => "--ssh",
-            if !matches!(opts.platform, Platform::Native) => [
+            if let Some(platform) = opts.platform => [
                 "--platform",
-                opts.platform.to_string(),
+                platform.to_string(),
             ],
             "--pull=true",
             format!("--layers={}", !opts.squash),

--- a/process/drivers/docker_driver.rs
+++ b/process/drivers/docker_driver.rs
@@ -30,7 +30,7 @@ use crate::{
             RunOptsVolume, TagOpts,
         },
         traits::{BuildDriver, DriverVersion, InspectDriver, RunDriver},
-        types::{ContainerId, ImageMetadata, ImageRef, Platform},
+        types::{ContainerId, ImageMetadata, ImageRef},
     },
     logging::CommandLogging,
     signal_handler::{ContainerRuntime, ContainerSignalId, add_cid, remove_cid},
@@ -207,9 +207,9 @@ impl BuildDriver for DockerDriver {
             let c = cmd!(
                 "docker",
                 "build",
-                if !matches!(opts.platform, Platform::Native) => [
+                if let Some(platform) = opts.platform => [
                     "--platform",
-                    opts.platform.to_string(),
+                    platform.to_string(),
                 ],
                 "-t",
                 opts.image.to_string(),
@@ -456,9 +456,9 @@ fn build_tag_push_cmd(
                 }).collect()
             }),
         "--pull",
-        if !matches!(opts.platform, Platform::Native) => [
+        if let Some(platform) = opts.platform => [
             "--platform",
-            opts.platform.to_string(),
+            platform.to_string(),
         ],
         "-f",
         &*opts.containerfile,
@@ -507,7 +507,7 @@ impl InspectDriver for DockerDriver {
 #[cached(
     result = true,
     key = "String",
-    convert = r#"{ format!("{}-{}", opts.image, opts.platform)}"#,
+    convert = r#"{ format!("{}-{:?}", opts.image, opts.platform)}"#,
     sync_writes = "by_key"
 )]
 fn get_metadata_cache(opts: &GetMetadataOpts) -> Result<ImageMetadata> {

--- a/process/drivers/github_driver.rs
+++ b/process/drivers/github_driver.rs
@@ -41,7 +41,7 @@ impl CiDriver for GithubDriver {
         let timestamp = blue_build_utils::get_tag_timestamp();
         let os_version = Driver::get_os_version()
             .oci_ref(opts.oci_ref)
-            .platform(opts.platform)
+            .maybe_platform(opts.platform)
             .call()
             .inspect(|v| trace!("os_version={v}"))?;
         let ref_name = get_env_var(GITHUB_REF_NAME)

--- a/process/drivers/gitlab_driver.rs
+++ b/process/drivers/gitlab_driver.rs
@@ -49,7 +49,7 @@ impl CiDriver for GitlabDriver {
         const MR_EVENT: &str = "merge_request_event";
         let os_version = Driver::get_os_version()
             .oci_ref(opts.oci_ref)
-            .platform(opts.platform)
+            .maybe_platform(opts.platform)
             .call()?;
         let timestamp = blue_build_utils::get_tag_timestamp();
         let short_sha =

--- a/process/drivers/local_driver.rs
+++ b/process/drivers/local_driver.rs
@@ -26,7 +26,7 @@ impl CiDriver for LocalDriver {
         trace!("LocalDriver::generate_tags({opts:?})");
         let os_version = Driver::get_os_version()
             .oci_ref(opts.oci_ref)
-            .platform(opts.platform)
+            .maybe_platform(opts.platform)
             .call()?;
         let timestamp = blue_build_utils::get_tag_timestamp();
         let short_sha = commit_sha();

--- a/process/drivers/opts/build.rs
+++ b/process/drivers/opts/build.rs
@@ -20,8 +20,7 @@ pub struct BuildOpts<'scope> {
     #[builder(into)]
     pub containerfile: Cow<'scope, Path>,
 
-    #[builder(default)]
-    pub platform: Platform,
+    pub platform: Option<Platform>,
 
     #[builder(default)]
     pub host_network: bool,
@@ -102,8 +101,7 @@ pub struct BuildTagPushOpts<'scope> {
     pub squash: bool,
 
     /// The platform to build the image on.
-    #[builder(default)]
-    pub platform: Platform,
+    pub platform: Option<Platform>,
 
     /// Runs the build with elevated privileges
     #[builder(default)]

--- a/process/drivers/opts/ci.rs
+++ b/process/drivers/opts/ci.rs
@@ -12,8 +12,7 @@ pub struct GenerateTagsOpts<'scope> {
     #[builder(into)]
     pub alt_tags: Option<Vec<Cow<'scope, str>>>,
 
-    #[builder(default)]
-    pub platform: Platform,
+    pub platform: Option<Platform>,
 }
 
 #[derive(Debug, Clone, Builder)]

--- a/process/drivers/opts/inspect.rs
+++ b/process/drivers/opts/inspect.rs
@@ -9,6 +9,5 @@ pub struct GetMetadataOpts<'scope> {
     #[builder(into)]
     pub image: &'scope Reference,
 
-    #[builder(default)]
-    pub platform: Platform,
+    pub platform: Option<Platform>,
 }

--- a/process/drivers/opts/rechunk.rs
+++ b/process/drivers/opts/rechunk.rs
@@ -16,8 +16,7 @@ pub struct RechunkOpts<'scope> {
     #[builder(into)]
     pub containerfile: Cow<'scope, Path>,
 
-    #[builder(default)]
-    pub platform: Platform,
+    pub platform: Option<Platform>,
     pub version: Cow<'scope, str>,
     pub name: Cow<'scope, str>,
     pub description: Cow<'scope, str>,

--- a/process/drivers/opts/signing.rs
+++ b/process/drivers/opts/signing.rs
@@ -114,6 +114,5 @@ pub struct SignVerifyOpts<'scope> {
     #[builder(default = 1)]
     pub retry_count: u8,
 
-    #[builder(default)]
-    pub platform: Platform,
+    pub platform: Option<Platform>,
 }

--- a/process/drivers/podman_driver.rs
+++ b/process/drivers/podman_driver.rs
@@ -28,7 +28,7 @@ use crate::{
     drivers::{
         BuildDriver, DriverVersion, InspectDriver, RunDriver,
         opts::{BuildOpts, GetMetadataOpts, PushOpts, RunOpts, RunOptsEnv, RunOptsVolume, TagOpts},
-        types::{ImageMetadata, Platform},
+        types::ImageMetadata,
     },
     logging::{CommandLogging, Logger},
     signal_handler::{ContainerRuntime, ContainerSignalId, add_cid, remove_cid},
@@ -158,9 +158,9 @@ impl BuildDriver for PodmanDriver {
                 "podman",
             ],
             "build",
-            if !matches!(opts.platform, Platform::Native) => [
+            if let Some(platform) = opts.platform => [
                 "--platform",
-                opts.platform.to_string(),
+                platform.to_string(),
             ],
             if let Some(cache_from) = opts.cache_from.as_ref() => [
                 "--cache-from",
@@ -347,7 +347,7 @@ impl InspectDriver for PodmanDriver {
 #[cached(
     result = true,
     key = "String",
-    convert = r#"{ format!("{}-{}", opts.image, opts.platform)}"#,
+    convert = r#"{ format!("{}-{:?}", opts.image, opts.platform)}"#,
     sync_writes = "by_key"
 )]
 fn get_metadata_cache(opts: &GetMetadataOpts) -> Result<ImageMetadata> {
@@ -369,9 +369,9 @@ fn get_metadata_cache(opts: &GetMetadataOpts) -> Result<ImageMetadata> {
         let c = cmd!(
             "podman",
             "pull",
-            if !matches!(opts.platform, Platform::Native) => [
+            if let Some(platform) = opts.platform => [
                 "--platform",
-                opts.platform.to_string(),
+                platform.to_string(),
             ],
             &image_str,
         );

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -124,7 +124,7 @@ pub trait BuildDriver: PrivateDriver {
         let build_opts = BuildOpts::builder()
             .image(&opts.image)
             .containerfile(opts.containerfile.as_ref())
-            .platform(opts.platform)
+            .maybe_platform(opts.platform)
             .squash(opts.squash)
             .maybe_cache_from(opts.cache_from)
             .maybe_cache_to(opts.cache_to)
@@ -286,7 +286,7 @@ pub trait RechunkDriver: RunDriver + BuildDriver + ContainerMountDriver {
             &BuildOpts::builder()
                 .image(raw_image)
                 .containerfile(&*opts.containerfile)
-                .platform(opts.platform)
+                .maybe_platform(opts.platform)
                 .privileged(true)
                 .squash(true)
                 .host_network(true)
@@ -562,7 +562,7 @@ pub trait SigningDriver: PrivateDriver {
         let image_digest = Driver::get_metadata(
             &GetMetadataOpts::builder()
                 .image(opts.image)
-                .platform(opts.platform)
+                .maybe_platform(opts.platform)
                 .build(),
         )?
         .digest;

--- a/process/drivers/types.rs
+++ b/process/drivers/types.rs
@@ -8,6 +8,7 @@ use blue_build_utils::{
     constants::{GITHUB_ACTIONS, GITLAB_CI, IMAGE_VERSION_LABEL},
     get_env_var,
     semver::Version,
+    string,
 };
 use clap::ValueEnum;
 use log::{trace, warn};
@@ -19,6 +20,10 @@ use crate::drivers::{
     DriverVersion, buildah_driver::BuildahDriver, docker_driver::DockerDriver,
     podman_driver::PodmanDriver,
 };
+
+mod private {
+    pub trait Private {}
+}
 
 pub(super) trait DetermineDriver<T> {
     fn determine_driver(&mut self) -> T;
@@ -178,30 +183,86 @@ impl DetermineDriver<CiDriverType> for Option<CiDriverType> {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, ValueEnum, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Hash)]
 pub enum Platform {
-    #[default]
-    #[value(name = "native")]
-    Native,
     #[value(name = "linux/amd64")]
     LinuxAmd64,
 
+    #[value(name = "linux/amd64/v2")]
+    LinuxAmd64V2,
+
     #[value(name = "linux/arm64")]
     LinuxArm64,
+
+    #[value(name = "linux/arm")]
+    LinuxArm,
+
+    #[value(name = "linux/arm/v6")]
+    LinuxArmV6,
+
+    #[value(name = "linux/arm/v7")]
+    LinuxArmV7,
+
+    #[value(name = "linux/386")]
+    Linux386,
+
+    #[value(name = "linux/loong64")]
+    LinuxLoong64,
+
+    #[value(name = "linux/mips")]
+    LinuxMips,
+
+    #[value(name = "linux/mipsle")]
+    LinuxMipsle,
+
+    #[value(name = "linux/mips64")]
+    LinuxMips64,
+
+    #[value(name = "linux/mips64le")]
+    LinuxMips64le,
+
+    #[value(name = "linux/ppc64")]
+    LinuxPpc64,
+
+    #[value(name = "linux/ppc64le")]
+    LinuxPpc64le,
+
+    #[value(name = "linux/riscv64")]
+    LinuxRiscv64,
+
+    #[value(name = "linux/s390x")]
+    LinuxS390x,
 }
 
 impl Platform {
     /// The architecture of the platform.
     #[must_use]
-    pub fn arch(&self) -> &str {
+    pub const fn arch(&self) -> &str {
         match *self {
-            Self::Native => match std::env::consts::ARCH {
-                "x86_64" => "amd64",
-                "aarch64" => "arm64",
-                arch => unimplemented!("Arch {arch} is unsupported"),
-            },
-            Self::LinuxAmd64 => "amd64",
+            Self::LinuxAmd64 | Self::LinuxAmd64V2 => "amd64",
             Self::LinuxArm64 => "arm64",
+            Self::LinuxArm | Self::LinuxArmV6 | Self::LinuxArmV7 => "arm",
+            Self::Linux386 => "386",
+            Self::LinuxLoong64 => "loong64",
+            Self::LinuxMips => "mips",
+            Self::LinuxMipsle => "mipsle",
+            Self::LinuxMips64 => "mips64",
+            Self::LinuxMips64le => "mips64le",
+            Self::LinuxPpc64 => "ppc64",
+            Self::LinuxPpc64le => "ppc64le",
+            Self::LinuxRiscv64 => "riscv64",
+            Self::LinuxS390x => "s390x",
+        }
+    }
+
+    /// The variant of the platform.
+    #[must_use]
+    pub const fn variant(&self) -> Option<&str> {
+        match *self {
+            Self::LinuxAmd64V2 => Some("v2"),
+            Self::LinuxArmV6 => Some("v6"),
+            Self::LinuxArmV7 => Some("v7"),
+            _ => None,
         }
     }
 }
@@ -212,14 +273,61 @@ impl std::fmt::Display for Platform {
             f,
             "{}",
             match *self {
-                Self::Native => match std::env::consts::ARCH {
-                    "x86_64" => "linux/amd64",
-                    "aarch64" => "linux/arm64",
-                    arch => unimplemented!("Arch {arch} is unsupported"),
-                },
                 Self::LinuxAmd64 => "linux/amd64",
+                Self::LinuxAmd64V2 => "linux/amd64/v2",
                 Self::LinuxArm64 => "linux/arm64",
+                Self::LinuxArm => "linux/arm",
+                Self::LinuxArmV6 => "linux/arm/v6",
+                Self::LinuxArmV7 => "linux/arm/v7",
+                Self::Linux386 => "linux/386",
+                Self::LinuxLoong64 => "linux/loong64",
+                Self::LinuxMips => "linux/mips",
+                Self::LinuxMipsle => "linux/mipsle",
+                Self::LinuxMips64 => "linux/mips64",
+                Self::LinuxMips64le => "linux/mips64le",
+                Self::LinuxPpc64 => "linux/ppc64",
+                Self::LinuxPpc64le => "linux/ppc64le",
+                Self::LinuxRiscv64 => "linux/riscv64",
+                Self::LinuxS390x => "linux/s390x",
             }
+        )
+    }
+}
+
+impl private::Private for Option<Platform> {}
+
+pub trait PlatformInfo: private::Private {
+    /// The string representation of the platform.
+    ///
+    /// If `None`, then the native architecture will be used.
+    fn to_string(&self) -> String;
+
+    /// The string representation of the architecture.
+    ///
+    /// If `None`, then the native architecture will be used.
+    fn arch(&self) -> &str;
+}
+
+impl PlatformInfo for Option<Platform> {
+    fn to_string(&self) -> String {
+        self.map_or_else(
+            || match std::env::consts::ARCH {
+                "x86_64" => string!("linux/amd64"),
+                "aarch64" => string!("linux/arm64"),
+                arch => unimplemented!("Arch {arch} is unsupported"),
+            },
+            |platform| format!("{platform}"),
+        )
+    }
+
+    fn arch(&self) -> &str {
+        self.as_ref().map_or_else(
+            || match std::env::consts::ARCH {
+                "x86_64" => "amd64",
+                "aarch64" => "arm64",
+                arch => unimplemented!("Arch {arch} is unsupported"),
+            },
+            Platform::arch,
         )
     }
 }


### PR DESCRIPTION
This add support for building images for all platforms that are supported by `podman` and `docker`. This will be the pre-cursor to [adding support for specifying platforms to build in the recipe](https://github.com/blue-build/cli/issues/340) and closes #499 .

According to the `podman-build` man page, [this](https://go.dev/doc/install/source#environment) is the source for all platform variants.