### PR TITLE
feat: Add one true optfix

### DIFF
--- a/scripts/post_build.sh
+++ b/scripts/post_build.sh
@@ -15,7 +15,7 @@ if [[ -n "${optdirs[*]}" ]]; then
         lib_opt_dir="${optfix_dir}/${opt}"
         mv -v "${optdir}" "${lib_opt_dir}"
         echo "linking ${optdir} => ${lib_opt_dir}"
-        echo "L  ${optdir}  -  -  -  -  ${lib_opt_dir}" | tee "/usr/lib/tmpfiles.d/bluebuild-optfix-${opt}.conf"
+        echo "L+?  ${optdir}  -  -  -  -  ${lib_opt_dir}" | tee "/usr/lib/tmpfiles.d/bluebuild-optfix-${opt}.conf"
     done
 fi
 


### PR DESCRIPTION
this (should!) fix anything that ended up in /opt, from e.g., rpm package installs, without needing to manually specify optfix folders in e.g., the dnf or rpm-ostree modules.

(awaits testing, how do i test this?)