### PR TITLE
fix: "or", not "and", in `Recipe::should_install_bins`

### DIFF
--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -160,7 +160,7 @@ impl Recipe {
 
     #[must_use]
     pub const fn should_install_bins(&self) -> bool {
-        self.should_install_bluebuild() && self.should_install_cosign()
+        self.should_install_bluebuild() || self.should_install_cosign()
     }
 
     #[must_use]


### PR DESCRIPTION
`Recipe::should_install_bins` should be true when we should install either cosign or bluebuild, not only when we should install both.