### PR TITLE
fix: Support more lenient version strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,45 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
         run: just test-empty-files-build
 
+  bluefin-build:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repo contents
+      packages: write # write test package to ghcr
+      id-token: write # docker auth
+
+    steps:
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+
+      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          install: true
+
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
+
+      # Setup repo and add caching
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repo }}
+
+
+      - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
+
+      - name: Run Build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
+        run: just test-bluefin-build
+
   build-chunked-oci-build:
     timeout-minutes: 40
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,6 @@ dependencies = [
  "directories",
  "docker_credential",
  "lazy-regex",
- "lenient_semver",
  "log",
  "miette",
  "nix",
@@ -2469,35 +2468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
-]
-
-[[package]]
-name = "lenient_semver"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
-dependencies = [
- "lenient_semver_parser",
- "semver",
-]
-
-[[package]]
-name = "lenient_semver_parser"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
-dependencies = [
- "lenient_semver_version_builder",
- "semver",
-]
-
-[[package]]
-name = "lenient_semver_version_builder"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
-dependencies = [
- "semver",
 ]
 
 [[package]]

--- a/integration-tests/test-repo/recipes/recipe-bluefin.yml
+++ b/integration-tests/test-repo/recipes/recipe-bluefin.yml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
+name: cli/test-bluefin
+description: This is my personal OS image.
+base-image: ghcr.io/ublue-os/bluefin
+blue-build-tag: none
+cosign-version: none
+image-version: stable
+stages:
+  - from-file: stages.yml
+modules:
+  - from-file: common.yml

--- a/justfile
+++ b/justfile
@@ -162,6 +162,16 @@ test-empty-files-build: generate-test-secret install-debug-all-features
     {{ should_push }} \
     -vv
 
+test-bluefin-build: generate-test-secret install-debug-all-features
+  cd integration-tests/test-repo \
+  && bluebuild build \
+    --retry-push \
+    -B docker \
+    -S sigstore \
+    {{ should_push }} \
+    -vv \
+    recipes/recipe-bluefin.yml
+
 test-build-chunked-oci-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
   && bluebuild build \

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,7 +14,6 @@ blake2 = "0.10.6"
 constcat = "0.6.1"
 directories = "6.0.0"
 docker_credential = "1.3.2"
-lenient_semver = "0.4.2"
 process_control = { version = "4.2.2", features = ["crossbeam-channel"] }
 
 bon.workspace = true

--- a/utils/src/semver.rs
+++ b/utils/src/semver.rs
@@ -1,23 +1,27 @@
-use std::str::FromStr;
+use std::{ops::Not, str::FromStr};
 
+use lazy_regex::regex_captures;
 use miette::bail;
-use semver::Prerelease;
+use semver::{BuildMetadata, Prerelease};
 use serde::{Deserialize, Serialize, de::Error};
 
 #[derive(Debug, Clone, Serialize)]
-pub struct Version(semver::Version);
+pub struct Version {
+    prefix: Option<String>,
+    version: semver::Version,
+}
 
 impl std::ops::Deref for Version {
     type Target = semver::Version;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.version
     }
 }
 
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        self.version.fmt(f)
     }
 }
 
@@ -27,9 +31,7 @@ impl<'de> Deserialize<'de> for Version {
         D: serde::Deserializer<'de>,
     {
         let ver = String::deserialize(deserializer)?;
-        ver.trim()
-            .trim_start_matches('v')
-            .parse()
+        ver.parse()
             .map_err(|e: miette::Error| D::Error::custom(e.to_string()))
     }
 }
@@ -38,11 +40,61 @@ impl FromStr for Version {
     type Err = miette::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let Ok(mut parsed_ver) = lenient_semver::parse(s) else {
-            bail!("Failed to deserialize version {s}");
+        let Some((_whole, prefix, major, minor, patch)) = regex_captures!(
+            r"(?:(?<prefix>[a-zA-Z0-9_-]+)-)?v?(?<major>\d+)(?:\.(?<minor>\d+))?(?:\.(?<patch>\d+))?(?:[-_].*)?",
+            s.trim()
+        ) else {
+            bail!("Failed to parse version {s} with regex");
         };
+
+        let Ok(mut version) = semver::Version::parse(&format!(
+            "{major}.{minor}.{patch}",
+            minor = if minor.is_empty() { "0" } else { minor },
+            patch = if patch.is_empty() { "0" } else { patch }
+        )) else {
+            bail!("Failed to parse version {s}");
+        };
+
         // delete pre-release field or we can never match pre-release versions of tools
-        parsed_ver.pre = Prerelease::EMPTY;
-        Ok(Self(parsed_ver))
+        version.pre = Prerelease::EMPTY;
+        version.build = BuildMetadata::EMPTY;
+
+        let prefix = prefix.is_empty().not().then(|| prefix.into());
+
+        Ok(Self { prefix, version })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use crate::semver::Version;
+
+    #[rstest]
+    #[case("42", None, 42, 0, 0)]
+    #[case("42.20251020.1", None, 42, 20_251_020, 1)]
+    #[case("42.20251020", None, 42, 20_251_020, 0)]
+    #[case("latest-42.20251020.1", Some("latest"), 42, 20_251_020, 1)]
+    #[case("42-beta.0", None, 42, 0, 0)]
+    #[case("stable-42-beta.0", Some("stable"), 42, 0, 0)]
+    #[case("v42", None, 42, 0, 0)]
+    #[case("v42.20251020.1", None, 42, 20_251_020, 1)]
+    #[case("v42.20251020", None, 42, 20_251_020, 0)]
+    #[case("latest-v42.20251020.1", Some("latest"), 42, 20_251_020, 1)]
+    #[case("v42-beta.0", None, 42, 0, 0)]
+    #[case("stable-v42-beta.0", Some("stable"), 42, 0, 0)]
+    fn parse_version(
+        #[case] version: &str,
+        #[case] prefix: Option<&str>,
+        #[case] major: u64,
+        #[case] minor: u64,
+        #[case] patch: u64,
+    ) {
+        let version = version.parse::<Version>().unwrap();
+        assert_eq!(version.prefix.as_deref(), prefix);
+        assert_eq!(version.version.major, major);
+        assert_eq!(version.version.minor, minor);
+        assert_eq!(version.version.patch, patch);
     }
 }


### PR DESCRIPTION
This removes the unmaintained `lenient_semver` crate and instead makes use of regex to parse any prefix that could be there. Also adds some tests to confirm that Bluefin (the perpetrator image) can have it's version parsed properly.