### PR TITLE
fix: set compression format in manifest_push

### DIFF
--- a/process/drivers/buildah_driver.rs
+++ b/process/drivers/buildah_driver.rs
@@ -310,6 +310,9 @@ impl BuildDriver for BuildahDriver {
                 "manifest",
                 "push",
                 "--all",
+                if let Some(compression_fmt) = opts.compression_type => format!(
+                    "--compression-format={compression_fmt}"
+                ),
                 image,
                 format!("docker://{}", opts.final_image),
             );

--- a/process/drivers/opts/build.rs
+++ b/process/drivers/opts/build.rs
@@ -98,6 +98,9 @@ pub struct ManifestCreateOpts<'scope> {
 pub struct ManifestPushOpts<'scope> {
     /// The final image to push.
     pub final_image: &'scope Reference,
+
+    /// Compression format to use when pushing images in manifest.
+    pub compression_type: Option<CompressionType>,
 }
 
 /// Options for building, tagging, and pushing images.

--- a/process/drivers/podman_driver.rs
+++ b/process/drivers/podman_driver.rs
@@ -396,6 +396,9 @@ impl BuildDriver for PodmanDriver {
                 "podman",
                 "manifest",
                 "push",
+                if let Some(compression_fmt) = opts.compression_type => format!(
+                    "--compression-format={compression_fmt}"
+                ),
                 image,
                 format!("docker://{}", opts.final_image),
             );
@@ -471,6 +474,9 @@ impl BuildChunkedOciDriver for PodmanDriver {
                 for args,
                 "push",
                 if let Some(authfile) = runner.authfile() => ["--authfile", authfile],
+                if let Some(compression_fmt) = opts.compression_type => format!(
+                    "--compression-format={compression_fmt}"
+                ),
                 image,
                 format!("docker://{}", opts.final_image),
             );

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -237,6 +237,7 @@ pub trait BuildDriver: PrivateDriver {
                             Self::manifest_push(
                                 ManifestPushOpts::builder()
                                     .final_image(&tagged_image)
+                                    .compression_type(opts.compression)
                                     .build(),
                             )
                         })?;
@@ -555,6 +556,7 @@ pub trait BuildChunkedOciDriver: BuildDriver + RunDriver {
                                 &runner,
                                 ManifestPushOpts::builder()
                                     .final_image(&tagged_image)
+                                    .compression_type(btp_opts.compression)
                                     .build(),
                             )
                             .and_then(|()| {
@@ -562,6 +564,7 @@ pub trait BuildChunkedOciDriver: BuildDriver + RunDriver {
                                     &runner,
                                     ManifestPushOpts::builder()
                                         .final_image(&tagged_image)
+                                        .compression_type(btp_opts.compression)
                                         .build(),
                                 )
                             })


### PR DESCRIPTION
The `--compression-format` option had been getting ignored by the podman and buildah drivers when calling `manifest_push`.

Fixes #648.