### PR TITLE
fix: pull prior build for build-chunked-oci to use as baseline

### DIFF
--- a/process/drivers.rs
+++ b/process/drivers.rs
@@ -36,9 +36,9 @@ use crate::{logging::Logger, signal_handler::DetachedContainer};
 use opts::{
     BuildChunkedOciOpts, BuildOpts, BuildRechunkTagPushOpts, BuildTagPushOpts, CheckKeyPairOpts,
     ContainerOpts, CopyOciOpts, CreateContainerOpts, GenerateImageNameOpts, GenerateKeyPairOpts,
-    GenerateTagsOpts, GetMetadataOpts, ManifestCreateOpts, ManifestPushOpts, PruneOpts, PushOpts,
-    RechunkOpts, RemoveContainerOpts, RemoveImageOpts, RunOpts, SignOpts, SwitchOpts, TagOpts,
-    UntagOpts, VerifyOpts, VolumeOpts,
+    GenerateTagsOpts, GetMetadataOpts, ManifestCreateOpts, ManifestPushOpts, PruneOpts, PullOpts,
+    PushOpts, RechunkOpts, RemoveContainerOpts, RemoveImageOpts, RunOpts, SignOpts, SwitchOpts,
+    TagOpts, UntagOpts, VerifyOpts, VolumeOpts,
 };
 use types::{
     BootDriverType, BuildDriverType, CiDriverType, ImageMetadata, InspectDriverType, RunDriverType,
@@ -344,6 +344,10 @@ impl BuildDriver for Driver {
         impl_build_driver!(push(opts))
     }
 
+    fn pull(opts: PullOpts) -> Result<ContainerId> {
+        impl_build_driver!(pull(opts))
+    }
+
     fn login(server: &str) -> Result<()> {
         impl_build_driver!(login(server))
     }
@@ -498,6 +502,14 @@ impl BuildChunkedOciDriver for Driver {
 
     fn manifest_push_with_runner(runner: &RpmOstreeRunner, opts: ManifestPushOpts) -> Result<()> {
         PodmanDriver::manifest_push_with_runner(runner, opts)
+    }
+
+    fn pull_with_runner(runner: &RpmOstreeRunner, opts: PullOpts) -> Result<ContainerId> {
+        PodmanDriver::pull_with_runner(runner, opts)
+    }
+
+    fn remove_image_with_runner(runner: &RpmOstreeRunner, image_ref: &str) -> Result<()> {
+        PodmanDriver::remove_image_with_runner(runner, image_ref)
     }
 
     fn build_chunked_oci(

--- a/process/drivers/opts/build.rs
+++ b/process/drivers/opts/build.rs
@@ -66,6 +66,17 @@ pub struct PushOpts<'scope> {
 
 #[derive(Debug, Clone, Copy, Builder)]
 #[builder(derive(Debug, Clone))]
+pub struct PullOpts<'scope> {
+    pub image: &'scope Reference,
+    pub platform: Option<Platform>,
+    pub retry_count: Option<u8>,
+
+    #[builder(default)]
+    pub privileged: bool,
+}
+
+#[derive(Debug, Clone, Copy, Builder)]
+#[builder(derive(Debug, Clone))]
 pub struct PruneOpts {
     pub all: bool,
     pub volumes: bool,

--- a/process/drivers/opts/build_chunked_oci.rs
+++ b/process/drivers/opts/build_chunked_oci.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use blue_build_utils::constants::DEFAULT_MAX_LAYERS;
+use blue_build_utils::{constants::DEFAULT_MAX_LAYERS, platform::Platform};
 use bon::Builder;
 
 use super::BuildTagPushOpts;
@@ -22,6 +22,23 @@ pub struct BuildChunkedOciOpts {
     /// Maximum number of layers to use. Currently defaults to 64 if not specified.
     #[builder(default = DEFAULT_MAX_LAYERS)]
     pub max_layers: NonZeroU32,
+
+    /// Build layer plan from scratch instead of using the previous build as a baseline.
+    #[builder(default)]
+    pub clear_plan: bool,
+
+    /// Platform to use for baseline previous build.
+    pub platform: Option<Platform>,
+}
+
+impl BuildChunkedOciOpts {
+    #[must_use]
+    pub const fn with_platform(self, platform: Platform) -> Self {
+        Self {
+            platform: Some(platform),
+            ..self
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -150,7 +150,7 @@ pub struct BuildCommand {
 
     /// Use a fresh rechunk plan, regardless of previous ref.
     ///
-    /// NOTE: Only works with `--rechunk`.
+    /// NOTE: Only works with `--build-chunked-oci` or `--rechunk`.
     #[arg(long, env = BB_BUILD_RECHUNK_CLEAR_PLAN)]
     #[builder(default)]
     rechunk_clear_plan: bool,
@@ -382,6 +382,7 @@ impl BuildCommand {
         let images = if self.build_chunked_oci {
             let rechunk_opts = BuildChunkedOciOpts::builder()
                 .max_layers(self.max_layers)
+                .clear_plan(self.rechunk_clear_plan)
                 .build();
             Driver::build_rechunk_tag_push(
                 BuildRechunkTagPushOpts::builder()


### PR DESCRIPTION
build-chunked-oci requires a prior build to be stored locally for it to be used as a baseline for the layer chunking plan. The prior build is removed after rechunking to avoid taking up more space than necessary.