### PR TITLE
chore: prune after removing base image when rechunking

### DIFF
--- a/process/drivers/opts/build.rs
+++ b/process/drivers/opts/build.rs
@@ -78,7 +78,10 @@ pub struct PullOpts<'scope> {
 #[derive(Debug, Clone, Copy, Builder)]
 #[builder(derive(Debug, Clone))]
 pub struct PruneOpts {
+    #[builder(default)]
     pub all: bool,
+
+    #[builder(default)]
     pub volumes: bool,
 }
 

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -26,9 +26,9 @@ use super::{
     opts::{
         BuildChunkedOciOpts, BuildOpts, BuildRechunkTagPushOpts, BuildTagPushOpts,
         CheckKeyPairOpts, ContainerOpts, CopyOciOpts, CreateContainerOpts, GenerateImageNameOpts,
-        GenerateKeyPairOpts, GenerateTagsOpts, GetMetadataOpts, PullOpts, PushOpts, RechunkOpts,
-        RemoveContainerOpts, RemoveImageOpts, RunOpts, SignOpts, SignVerifyOpts, SwitchOpts,
-        TagOpts, UntagOpts, VerifyOpts, VerifyType, VolumeOpts,
+        GenerateKeyPairOpts, GenerateTagsOpts, GetMetadataOpts, PruneOpts, PullOpts, PushOpts,
+        RechunkOpts, RemoveContainerOpts, RemoveImageOpts, RunOpts, SignOpts, SignVerifyOpts,
+        SwitchOpts, TagOpts, UntagOpts, VerifyOpts, VerifyType, VolumeOpts,
     },
     opts::{ManifestCreateOpts, ManifestPushOpts},
     rpm_ostree_runner::RpmOstreeRunner,
@@ -468,6 +468,7 @@ pub trait BuildChunkedOciDriver: BuildDriver + ImageStorageDriver {
                     .privileged(btp_opts.privileged)
                     .build(),
             )?;
+            Self::prune(PruneOpts::builder().volumes(true).build())?;
         }
 
         // Run subsequent commands on host if rpm-ostree is available on host, otherwise

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -135,8 +135,9 @@ pub struct BuildCommand {
     #[builder(default = DEFAULT_MAX_LAYERS)]
     max_layers: NonZeroU32,
 
-    /// Removes the base image from local storage after the image is built, but
-    /// before running build-chunked-oci. This frees up additional disk space.
+    /// Removes the base image from local storage and prunes unused podman containers
+    /// and volumes after the image is built, but before running build-chunked-oci.
+    /// This frees up additional disk space.
     #[arg(long, env = BB_BUILD_REMOVE_BASE_IMAGE, requires = "build_chunked_oci")]
     #[builder(default)]
     remove_base_image: bool,


### PR DESCRIPTION
This frees up disk space in advance of running build-chunked-oci.

Tested and confirmed to free up disk space at: https://github.com/HastD/secureblue/actions/runs/20904265184/job/60054962539