### PR TITLE
fix: update rust-overlay to a more recent version in flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,44 +2,26 @@
   "nodes": {
     "flake-schemas": {
       "locked": {
-        "lastModified": 1697467827,
-        "narHash": "sha256-j8SR19V1SRysyJwpOBF4TLuAvAjF5t+gMiboN4gYQDU=",
-        "rev": "764932025c817d4e500a8d2a4d8c565563923d29",
-        "revCount": 29,
+        "lastModified": 1773853635,
+        "narHash": "sha256-4VHWij4EWNqy1iZr6OxNB6cuv5tDjMwAL/J1SBLFU2Q=",
+        "rev": "19686d6f3da8d4db959523f32eb1b50de9f18301",
+        "revCount": 130,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.2/018b3da8-4cc3-7fbb-8ff7-1588413c53e2/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.4.1/019d01eb-47d3-710f-aade-0515bfcdaa1f/source.tar.gz"
       },
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/%2A.tar.gz"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773068389,
-        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
-        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
-        "revCount": 909173,
+        "lastModified": 1774799055,
+        "narHash": "sha256-Tsq9BCz0q47ej1uFF39m4tuhcwru/ls6vCCJzutEpaw=",
+        "rev": "107cba9eb4a8d8c9f8e9e61266d78d340867913a",
+        "revCount": 910179,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.909173%2Brev-44bae273f9f82d480273bab26f5c50de3724f52f/019cdb71-ee45-7469-aca0-9d5b9fedf5c5/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.910179%2Brev-107cba9eb4a8d8c9f8e9e61266d78d340867913a/019d427e-213b-7e62-8a76-08115818fb82/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -55,37 +37,21 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1709086241,
-        "narHash": "sha256-3QHK5zu/5XOa+ghBeKzvt+/BLdEPjw/xDNLcpDfbkmg=",
+        "lastModified": 1774926780,
+        "narHash": "sha256-JMdDYn0F+swYBILlpCeHDbCSyzqkeSGNxZ/Q5J584jM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5d56056fb905ff550ee61b6ebb6674d494f57a9e",
+        "rev": "962a0934d0e32f42d1b5e49186f9595f9b178d2d",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }


### PR DESCRIPTION
This PR updates the rust-overlay via `nix flake update`, the previous version was stuck with the Rust 1.76 toolchain and so the project couldn't be built:

```sh
direnv: loading ~/Projects/almalinux/bluebuild/cli/.envrc
direnv: using flake
error: Cannot build '/nix/store/adyc3z90r4pq5m5z2vbjmskjpm10m2df-cargo-1.76.0-x86_64-unknown-linux-gnu.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/px40rqjp6p3yr8a7k146w7ib1jpkp14z-cargo-1.76.0-x86_64-unknown-linux-gnu
       Last 3 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/lkbacjsqhp3imp9ldyjh1qa6vrf7mayf-unknown
       > do not know how to unpack source archive /nix/store/lkbacjsqhp3imp9ldyjh1qa6vrf7mayf-unknown
       For full logs, run:
         nix log /nix/store/adyc3z90r4pq5m5z2vbjmskjpm10m2df-cargo-1.76.0-x86_64-unknown-linux-gnu.drv
error: Cannot build '/nix/store/1x0k6q3gjb1amxxx38mk506vbm8yi3id-rust-default-1.76.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/h40m10lc33bvy9qx6l33qdh4qlva78i9-rust-default-1.76.0
error: Cannot build '/nix/store/czgd2vk2ns4j4kh4wjj70dfm4hw0p9n0-nix-shell-env.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/04d30bawwbb8rd5601px9xik4lwx47wc-nix-shell-env
```