### PR TITLE
fix(recipe): change serde alias to rename

### DIFF
--- a/recipe/src/recipe.rs
+++ b/recipe/src/recipe.rs
@@ -37,15 +37,15 @@ pub struct Recipe {
     pub description: String,
 
     /// The base image from which to build the user's image.
-    #[serde(alias = "base-image")]
+    #[serde(rename = "base-image")]
     pub base_image: String,
 
     /// The version/tag of the base image.
-    #[serde(alias = "image-version")]
+    #[serde(rename = "image-version")]
     pub image_version: Tag,
 
     /// The version of `bluebuild` to install in the image
-    #[serde(alias = "blue-build-tag", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "blue-build-tag", skip_serializing_if = "Option::is_none")]
     pub blue_build_tag: Option<MaybeVersion>,
 
     /// Alternate tags to the `latest` tag to add to the image.
@@ -55,7 +55,7 @@ pub struct Recipe {
     /// timestamp with no version (e.g. `20240429`).
     ///
     /// Any user input will override the `latest` and timestamp tags.
-    #[serde(alias = "alt-tags", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "alt-tags", skip_serializing_if = "Option::is_none")]
     #[builder(into)]
     pub alt_tags: Option<Vec<Tag>>,
 


### PR DESCRIPTION
## Motivation

See #750 

`alias` only affects deserialization, `rename` affects both serialization and deserialization.

## Old behavior

```bash
$ bluebuild generate -d -q ./recipes/recipe.yaml -o ./recipes/recipe.flat.yaml
$ grep image recipes/recipe.flat.yaml
base_image: ghcr.io/ublue-os/silverblue-main
image_version: '44'
$ bluebuild validate ./recipes/recipe.flat.yaml
ERROR => Failed:
  × Recipe ./recipes/recipe.flat.yaml failed to validate
  ╰─▶   × 3 errors encountered
         ╭─[./recipes/recipe.flat.yaml:1:1]
       1 │ name: my-recipe
         · ┬┬┬
         · ││╰── "image-version" is a required property
         · │╰── "base-image" is a required property
         · ╰── Additional properties are not allowed ('base_image', 'image_version' were unexpected)
       3 │ base_image: ghcr.io/ublue-os/silverblue-main
       4 │ image_version: '44'
         ╰────
```

## New behavior

```bash
$ bluebuild generate -d -q ./recipes/recipe.yaml -o ./recipes/recipe.flat.yaml
$ grep image recipes/recipe.flat.yaml
base-image: ghcr.io/ublue-os/silverblue-main
image-version: '44'
$ bluebuild validate ./recipes/recipe.flat.yaml
$ bluebuild switch ./recipes/recipe.flat.yaml
```

## Tests

```
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s

     Running unittests src/bin/bluebuild.rs (target/debug/deps/bluebuild-c3cbb03b31652e2a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests blue_build

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Fix #750
