### PR TITLE
fix: use 0700 permissions for all temporary directories

### DIFF
--- a/process/drivers/buildah_driver.rs
+++ b/process/drivers/buildah_driver.rs
@@ -1,5 +1,6 @@
 use blue_build_utils::{
-    container::ContainerId, credentials::Credentials, secret::SecretArgs, semver::Version, sudo_cmd,
+    container::ContainerId, credentials::Credentials, secret::SecretArgs, semver::Version,
+    sudo_cmd, tempdir,
 };
 use colored::Colorize;
 use comlexr::{cmd, pipe};
@@ -7,7 +8,6 @@ use log::{debug, error, info, trace, warn};
 use miette::{Context, IntoDiagnostic, Result, bail};
 use oci_client::Reference;
 use serde::Deserialize;
-use tempfile::TempDir;
 
 use crate::logging::CommandLogging;
 
@@ -57,9 +57,7 @@ impl BuildDriver for BuildahDriver {
     fn build(opts: BuildOpts) -> Result<()> {
         trace!("BuildahDriver::build({opts:#?})");
 
-        let temp_dir = TempDir::new()
-            .into_diagnostic()
-            .wrap_err("Failed to create temporary directory for secrets")?;
+        let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         let command = sudo_cmd!(
             prompt = SUDO_PROMPT,

--- a/process/drivers/cosign_driver.rs
+++ b/process/drivers/cosign_driver.rs
@@ -229,8 +229,10 @@ impl SigningDriver for CosignDriver {
 mod test {
     use std::{fs, path::Path};
 
-    use blue_build_utils::constants::{COSIGN_PRIV_PATH, COSIGN_PUB_PATH};
-    use tempfile::TempDir;
+    use blue_build_utils::{
+        constants::{COSIGN_PRIV_PATH, COSIGN_PUB_PATH},
+        tempdir,
+    };
 
     use crate::drivers::{
         SigningDriver,
@@ -241,7 +243,7 @@ mod test {
 
     #[test]
     fn generate_key_pair() {
-        let tempdir = TempDir::new().unwrap();
+        let tempdir = tempdir().unwrap();
 
         CosignDriver::generate_key_pair(GenerateKeyPairOpts::builder().dir(tempdir.path()).build())
             .unwrap();
@@ -270,7 +272,7 @@ mod test {
     fn compatibility() {
         use crate::drivers::sigstore_driver::SigstoreDriver;
 
-        let tempdir = TempDir::new().unwrap();
+        let tempdir = tempdir().unwrap();
 
         CosignDriver::generate_key_pair(GenerateKeyPairOpts::builder().dir(tempdir.path()).build())
             .unwrap();

--- a/process/drivers/docker_driver.rs
+++ b/process/drivers/docker_driver.rs
@@ -11,7 +11,7 @@ use blue_build_utils::{
     get_env_var,
     secret::SecretArgs,
     semver::Version,
-    string_vec,
+    string_vec, tempdir,
 };
 use cached::proc_macro::once;
 use colored::Colorize;
@@ -193,9 +193,7 @@ impl BuildDriver for DockerDriver {
     fn build(opts: BuildOpts) -> Result<()> {
         trace!("DockerDriver::build({opts:#?})");
 
-        let temp_dir = TempDir::new()
-            .into_diagnostic()
-            .wrap_err("Failed to create temporary directory for secrets")?;
+        let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         if opts.squash {
             warn!("Squash is deprecated for docker so this build will not squash");
@@ -490,9 +488,7 @@ impl BuildDriver for DockerDriver {
     fn build_tag_push(opts: BuildTagPushOpts) -> Result<Vec<String>> {
         trace!("DockerDriver::build_tag_push({opts:#?})");
 
-        let temp_dir = TempDir::new()
-            .into_diagnostic()
-            .wrap_err("Failed to create temporary directory for secrets")?;
+        let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         if opts.squash {
             warn!("Squash is deprecated for docker so this build will not squash");
@@ -609,7 +605,7 @@ impl RunDriver for DockerDriver {
     fn run(opts: RunOpts) -> Result<ExitStatus> {
         trace!("DockerDriver::run({opts:#?})");
 
-        let cid_path = TempDir::new().into_diagnostic()?;
+        let cid_path = tempdir()?;
         let cid_file = cid_path.path().join("cid");
         let cid = ContainerSignalId::new(&cid_file, ContainerRuntime::Docker, false);
 
@@ -627,7 +623,7 @@ impl RunDriver for DockerDriver {
     fn run_output(opts: RunOpts) -> Result<std::process::Output> {
         trace!("DockerDriver::run_output({opts:#?})");
 
-        let cid_path = TempDir::new().into_diagnostic()?;
+        let cid_path = tempdir()?;
         let cid_file = cid_path.path().join("cid");
         let cid = ContainerSignalId::new(&cid_file, ContainerRuntime::Docker, false);
 
@@ -645,7 +641,7 @@ impl RunDriver for DockerDriver {
     fn run_detached(opts: RunOpts) -> Result<DetachedContainer> {
         trace!("DockerDriver::run_detached({opts:#?})");
 
-        let cid_path = TempDir::new().into_diagnostic()?;
+        let cid_path = tempdir()?;
         let cid_file = cid_path.path().join("cid");
 
         let cid = ContainerSignalId::new(&cid_file, ContainerRuntime::Docker, opts.privileged);

--- a/process/drivers/podman_driver.rs
+++ b/process/drivers/podman_driver.rs
@@ -11,7 +11,7 @@ use blue_build_utils::{
     get_env_var,
     secret::SecretArgs,
     semver::Version,
-    sudo_cmd,
+    sudo_cmd, tempdir,
 };
 use colored::Colorize;
 use comlexr::{cmd, pipe};
@@ -19,7 +19,6 @@ use log::{debug, error, info, trace, warn};
 use miette::{Context, IntoDiagnostic, Result, bail};
 use oci_client::Reference;
 use serde::Deserialize;
-use tempfile::TempDir;
 
 use super::{
     BuildChunkedOciDriver, BuildDriver, ContainerMountDriver, DriverVersion, ImageStorageDriver,
@@ -118,9 +117,7 @@ impl BuildDriver for PodmanDriver {
     fn build(opts: BuildOpts) -> Result<()> {
         trace!("PodmanDriver::build({opts:#?})");
 
-        let temp_dir = TempDir::new()
-            .into_diagnostic()
-            .wrap_err("Failed to create temporary directory for secrets")?;
+        let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         let command = sudo_cmd!(
             prompt = SUDO_PROMPT,
@@ -619,7 +616,7 @@ impl RunDriver for PodmanDriver {
     fn run(opts: RunOpts) -> Result<ExitStatus> {
         trace!("PodmanDriver::run({opts:#?})");
 
-        let cid_path = TempDir::new().into_diagnostic()?;
+        let cid_path = tempdir()?;
         let cid_file = cid_path.path().join("cid");
 
         let cid = ContainerSignalId::new(&cid_file, ContainerRuntime::Podman, opts.privileged);
@@ -638,7 +635,7 @@ impl RunDriver for PodmanDriver {
     fn run_output(opts: RunOpts) -> Result<std::process::Output> {
         trace!("PodmanDriver::run_output({opts:#?})");
 
-        let cid_path = TempDir::new().into_diagnostic()?;
+        let cid_path = tempdir()?;
         let cid_file = cid_path.path().join("cid");
 
         let cid = ContainerSignalId::new(&cid_file, ContainerRuntime::Podman, opts.privileged);
@@ -657,7 +654,7 @@ impl RunDriver for PodmanDriver {
     fn run_detached(opts: RunOpts) -> Result<DetachedContainer> {
         trace!("PodmanDriver::run_detached({opts:#?})");
 
-        let cid_path = TempDir::new().into_diagnostic()?;
+        let cid_path = tempdir()?;
         let cid_file = cid_path.path().join("cid");
 
         let cid = ContainerSignalId::new(&cid_file, ContainerRuntime::Podman, opts.privileged);

--- a/process/drivers/sigstore_driver.rs
+++ b/process/drivers/sigstore_driver.rs
@@ -254,8 +254,10 @@ impl SigningDriver for SigstoreDriver {
 mod test {
     use std::{fs, path::Path};
 
-    use blue_build_utils::constants::{COSIGN_PRIV_PATH, COSIGN_PUB_PATH};
-    use tempfile::TempDir;
+    use blue_build_utils::{
+        constants::{COSIGN_PRIV_PATH, COSIGN_PUB_PATH},
+        tempdir,
+    };
 
     use crate::drivers::{
         SigningDriver,
@@ -267,7 +269,7 @@ mod test {
 
     #[test]
     fn generate_key_pair() {
-        let tempdir = TempDir::new().unwrap();
+        let tempdir = tempdir().unwrap();
 
         SigstoreDriver::generate_key_pair(
             GenerateKeyPairOpts::builder().dir(tempdir.path()).build(),
@@ -298,7 +300,7 @@ mod test {
 
     #[test]
     fn compatibility() {
-        let tempdir = TempDir::new().unwrap();
+        let tempdir = tempdir().unwrap();
 
         SigstoreDriver::generate_key_pair(
             GenerateKeyPairOpts::builder().dir(tempdir.path()).build(),

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -11,7 +11,7 @@ use blue_build_utils::{
     platform::Platform,
     retry,
     semver::Version,
-    string_vec,
+    string_vec, tempdir, tempdir_in,
 };
 use comlexr::cmd;
 use log::{debug, info, trace, warn};
@@ -642,9 +642,9 @@ pub trait RechunkDriver: RunDriver + BuildDriver + ContainerMountDriver {
         );
 
         let temp_dir = if let Some(dir) = opts.tempdir {
-            &tempfile::TempDir::new_in(dir).into_diagnostic()?
+            tempdir_in(dir)?
         } else {
-            &tempfile::TempDir::new().into_diagnostic()?
+            tempdir()?
         };
         let ostree_cache_id = &uuid::Uuid::new_v4().to_string();
         let image = &ImageRef::from(
@@ -702,9 +702,9 @@ pub trait RechunkDriver: RunDriver + BuildDriver + ContainerMountDriver {
             Self::prune_image(mount, container, image, opts)?;
             Self::create_ostree_commit(mount, ostree_cache_id, container, image, opts)?;
 
-            let temp_dir_str = &*temp_dir.path().to_string_lossy();
+            let temp_dir_str = temp_dir.path().to_string_lossy();
 
-            Self::rechunk_image(ostree_cache_id, temp_dir_str, current_dir, opts)
+            Self::rechunk_image(ostree_cache_id, &temp_dir_str, current_dir, opts)
         })?;
 
         let mut image_list = Vec::with_capacity(opts.tags.len());

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -30,14 +30,14 @@ use blue_build_utils::{
     container::{ImageRef, Tag},
     credentials::{Credentials, CredentialsArgs},
     platform::Platform,
+    tempdir, tempdir_in,
 };
 use bon::Builder;
 use clap::Args;
 use log::{debug, info, trace, warn};
-use miette::{IntoDiagnostic, Result, bail};
+use miette::{Result, bail};
 use oci_client::Reference;
 use rayon::prelude::*;
-use tempfile::TempDir;
 
 use crate::commands::generate::{GenerateCommand, generate_default_labels};
 
@@ -221,9 +221,9 @@ impl BlueBuildCommand for BuildCommand {
         }
 
         let tempdir = if let Some(ref dir) = self.tempdir {
-            TempDir::new_in(dir).into_diagnostic()?
+            tempdir_in(dir)?
         } else {
-            TempDir::new().into_diagnostic()?
+            tempdir()?
         };
         let recipe_paths = self.recipe.clone().map_or_else(|| {
                 let legacy_path = Path::new(CONFIG_PATH);

--- a/src/commands/generate_iso.rs
+++ b/src/commands/generate_iso.rs
@@ -11,13 +11,12 @@ use blue_build_utils::{
         JASONN3_INSTALLER_IMAGE,
     },
     platform::Platform,
-    string_vec,
+    string_vec, tempdir, tempdir_in,
 };
 use bon::Builder;
 use clap::{Args, Subcommand, ValueEnum};
 use miette::{Context, IntoDiagnostic, Result, bail};
 use oci_client::Reference;
-use tempfile::TempDir;
 
 use blue_build_process_management::{
     drivers::{Driver, DriverArgs, RunDriver, opts::RunOpts},
@@ -150,9 +149,9 @@ impl BlueBuildCommand for GenerateIsoCommand {
         Driver::init(self.drivers);
 
         let image_out_dir = if let Some(ref dir) = self.tempdir {
-            TempDir::new_in(dir).into_diagnostic()?
+            tempdir_in(dir)?
         } else {
-            TempDir::new().into_diagnostic()?
+            tempdir()?
         };
 
         let output_dir = if let Some(output_dir) = self.output_dir.clone() {

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -6,12 +6,11 @@ use blue_build_process_management::drivers::{
     types::{BuildDriverType, RunDriverType},
 };
 use blue_build_recipe::Recipe;
-use blue_build_utils::{constants::BB_SKIP_VALIDATION, container::ImageRef};
+use blue_build_utils::{constants::BB_SKIP_VALIDATION, container::ImageRef, tempdir, tempdir_in};
 use bon::Builder;
 use clap::Args;
 use log::trace;
-use miette::{IntoDiagnostic, Result, bail};
-use tempfile::TempDir;
+use miette::{Result, bail};
 
 use crate::commands::generate::GenerateCommand;
 
@@ -70,9 +69,9 @@ impl BlueBuildCommand for SwitchCommand {
                 .build(),
         )?;
         let tempdir = if let Some(ref dir) = self.tempdir {
-            TempDir::new_in(dir).into_diagnostic()?
+            tempdir_in(dir)?
         } else {
-            TempDir::new().into_diagnostic()?
+            tempdir()?
         };
         let containerfile = tempdir
             .path()

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,8 +13,9 @@ pub mod test_utils;
 pub mod traits;
 
 use std::{
+    fs::Permissions,
     ops::{AsyncFnMut, Not},
-    os::unix::ffi::OsStrExt,
+    os::unix::{ffi::OsStrExt, fs::PermissionsExt},
     path::{Path, PathBuf},
     thread,
     time::Duration,
@@ -155,4 +156,32 @@ pub fn running_as_root() -> bool {
 #[must_use]
 pub fn current_timestamp() -> String {
     Utc::now().to_rfc3339()
+}
+
+/// Create a temporary directory readable only by the current user (0700
+/// permissions).
+///
+/// # Errors
+/// Will error if creating the temporary directory fails.
+pub fn tempdir() -> Result<tempfile::TempDir> {
+    tempfile::Builder::new()
+        .prefix("bluebuild-tmp-")
+        .permissions(Permissions::from_mode(0o700))
+        .rand_bytes(10) // this is the default for `mktemp`
+        .tempdir()
+        .into_diagnostic()
+}
+
+/// Create a temporary directory inside of `dir`, readable only by the current
+/// user (0700 permissions).
+///
+/// # Errors
+/// Will error if creating the temporary directory fails.
+pub fn tempdir_in<P: AsRef<Path>>(dir: P) -> Result<tempfile::TempDir> {
+    tempfile::Builder::new()
+        .prefix("bluebuild-tmp-")
+        .permissions(Permissions::from_mode(0o700))
+        .rand_bytes(10) // this is the default for `mktemp`
+        .tempdir_in(dir)
+        .into_diagnostic()
 }


### PR DESCRIPTION
The `tempfile` crate defaults to world-readable permissions for temporary directories, which we don't want. Instead, make a wrapper for creating tempdirs that sets 0700 permissions, and use this wrapper throughout the codebase.

Also change the prefix for tempdirs to "bluebuild-tmp-" so the source of tempdirs is clear if they aren't cleaned up, and increase the number of random bytes in the name to 10 to match the behavior of `mktemp`.