### PR TITLE
feat(cosign): allow configurable sign/verify args via env vars

### DIFF
--- a/process/drivers/cosign_driver.rs
+++ b/process/drivers/cosign_driver.rs
@@ -1,7 +1,9 @@
 use std::{fmt::Debug, fs, path::Path};
 
 use blue_build_utils::{
-    constants::{COSIGN_PASSWORD, COSIGN_PUB_PATH, COSIGN_YES},
+    constants::{
+        BB_COSIGN_SIGN_ARGS, BB_COSIGN_VERIFY_ARGS, COSIGN_PASSWORD, COSIGN_PUB_PATH, COSIGN_YES,
+    },
     credentials::Credentials,
     semver::Version,
 };
@@ -167,7 +169,7 @@ impl SigningDriver for CosignDriver {
     ) -> Result<()> {
         let image = image.clone_with_digest(metadata.digest().into());
         let status = {
-            let c = cmd!(
+            let mut c = cmd!(
                 env {
                     COSIGN_PASSWORD: "",
                     COSIGN_YES: "true",
@@ -182,6 +184,11 @@ impl SigningDriver for CosignDriver {
                 "--recursive",
                 image.to_string(),
             );
+            // Append operator-supplied flags to `cosign sign`, e.g.
+            // BB_COSIGN_SIGN_ARGS="--tlog-upload=false". Unset => no change.
+            if let Ok(extra) = std::env::var(BB_COSIGN_SIGN_ARGS) {
+                c.args(split_extra_args(&extra));
+            }
             trace!("{c:?}");
             c
         }
@@ -197,7 +204,7 @@ impl SigningDriver for CosignDriver {
 
     fn verify(opts: VerifyOpts) -> Result<()> {
         let status = {
-            let c = cmd!(
+            let mut c = cmd!(
                 "cosign",
                 "verify",
                 match &opts.verify_type {
@@ -211,6 +218,11 @@ impl SigningDriver for CosignDriver {
                 },
                 opts.image.to_string(),
             );
+            // Append operator-supplied flags to `cosign verify`, e.g.
+            // BB_COSIGN_VERIFY_ARGS="--insecure-ignore-tlog=true". Unset => none.
+            if let Ok(extra) = std::env::var(BB_COSIGN_VERIFY_ARGS) {
+                c.args(split_extra_args(&extra));
+            }
             trace!("{c:?}");
             c
         }
@@ -223,6 +235,18 @@ impl SigningDriver for CosignDriver {
 
         Ok(())
     }
+}
+
+/// Split an operator-supplied list of extra cosign flags (the value of
+/// [`BB_COSIGN_SIGN_ARGS`]/[`BB_COSIGN_VERIFY_ARGS`]) into individual
+/// arguments.
+///
+/// Tokens are separated by any run of ASCII whitespace, so a blank or
+/// whitespace-only value yields no arguments. This intentionally does not
+/// support shell quoting; each flag must be a single whitespace-free token
+/// (e.g. `--tlog-upload=false`).
+fn split_extra_args(raw: &str) -> Vec<String> {
+    raw.split_whitespace().map(ToString::to_string).collect()
 }
 
 #[cfg(test)]
@@ -239,7 +263,26 @@ mod test {
         opts::{CheckKeyPairOpts, GenerateKeyPairOpts},
     };
 
-    use super::CosignDriver;
+    use super::{CosignDriver, split_extra_args};
+
+    #[test]
+    fn split_extra_args_parses_tokens() {
+        // Unset/blank values contribute no arguments.
+        assert!(split_extra_args("").is_empty());
+        assert!(split_extra_args("   \t \n").is_empty());
+
+        // A single flag.
+        assert_eq!(
+            split_extra_args("--tlog-upload=false"),
+            ["--tlog-upload=false"]
+        );
+
+        // Multiple flags separated by arbitrary whitespace.
+        assert_eq!(
+            split_extra_args("  --insecure-ignore-tlog=true   --foo=bar\t--baz "),
+            ["--insecure-ignore-tlog=true", "--foo=bar", "--baz"]
+        );
+    }
 
     #[test]
     fn generate_key_pair() {

--- a/utils/src/constants.rs
+++ b/utils/src/constants.rs
@@ -39,6 +39,18 @@ pub const BB_BUILD_RECHUNK: &str = "BB_BUILD_RECHUNK";
 pub const BB_BUILD_RECHUNK_CLEAR_PLAN: &str = "BB_BUILD_RECHUNK_CLEAR_PLAN";
 pub const BB_BUILD_REMOVE_BASE_IMAGE: &str = "BB_BUILD_REMOVE_BASE_IMAGE";
 pub const BB_BUILD_SQUASH: &str = "BB_BUILD_SQUASH";
+/// Extra whitespace-separated flags appended to the `cosign sign` command.
+///
+/// Unset by default (no change). Useful for offline/private registries that
+/// cannot reach the public transparency log, e.g.
+/// `BB_COSIGN_SIGN_ARGS="--tlog-upload=false"`.
+pub const BB_COSIGN_SIGN_ARGS: &str = "BB_COSIGN_SIGN_ARGS";
+/// Extra whitespace-separated flags appended to the `cosign verify` command.
+///
+/// Unset by default (no change). Counterpart to [`BB_COSIGN_SIGN_ARGS`] for
+/// verifying images signed without a transparency-log entry, e.g.
+/// `BB_COSIGN_VERIFY_ARGS="--insecure-ignore-tlog=true"`.
+pub const BB_COSIGN_VERIFY_ARGS: &str = "BB_COSIGN_VERIFY_ARGS";
 pub const BB_GENISO_ENROLLMENT_PASSWORD: &str = "BB_GENISO_ENROLLMENT_PASSWORD";
 pub const BB_GENISO_ISO_NAME: &str = "BB_GENISO_ISO_NAME";
 pub const BB_GENISO_SECURE_BOOT_URL: &str = "BB_GENISO_SECURE_BOOT_URL";


### PR DESCRIPTION
The cosign signing driver builds fixed `cosign sign` / `cosign verify` commands with no way to pass extra flags. cosign defaults `--tlog-upload=true` on sign (publishing image digests to the public Rekor log and requiring internet) and, symmetrically, `cosign verify` requires a tlog entry by default — so an image signed offline cannot be verified by the build's own sign-and-verify step.

## Change

Add two **opt-in** env vars whose whitespace-separated tokens are appended to the respective command:

- `BB_COSIGN_SIGN_ARGS` → appended to `cosign sign`
- `BB_COSIGN_VERIFY_ARGS` → appended to `cosign verify`

Both are unset by default, so there is **no behavior change** for existing users. For a private/offline registry:

```
BB_COSIGN_SIGN_ARGS="--tlog-upload=false"
BB_COSIGN_VERIFY_ARGS="--insecure-ignore-tlog=true"
```

## Notes

- Env-var names are declared in `utils/src/constants.rs` per the existing convention and documented with rustdoc.
- Token splitting is factored into a small `split_extra_args` helper with a unit test (whitespace-only → no args, single flag, multiple flags). Shell quoting is intentionally not supported; each flag must be a single whitespace-free token.
- `cargo fmt --check`, `cargo clippy`, and the new unit test pass.
