### PR TITLE
feat: pull with retries before building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "shellexpand",
  "syntect",
  "tempfile",
+ "tokio",
  "uuid",
  "which",
  "yaml_serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_yaml = { version = "0.10.4", package = "yaml_serde" }
 structstruck = "0.5.1"
 syntect = { version = "5.3.0", default-features = false, features = ["default-fancy"] }
 tempfile = "3.27.0"
-tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.49.0", default-features = false }
 uuid = { version = "1.23.1", features = ["v4"] }
 which = "8.0.2"
 zeroize = { version = "1.8.2", features = ["aarch64", "derive", "std", "serde"] }
@@ -105,7 +105,7 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 bon.workspace = true
 
 [features]

--- a/process/Cargo.toml
+++ b/process/Cargo.toml
@@ -36,7 +36,7 @@ semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 uuid.workspace = true
 which.workspace = true
 zeroize.workspace = true

--- a/process/drivers/buildah_driver.rs
+++ b/process/drivers/buildah_driver.rs
@@ -59,6 +59,20 @@ impl BuildDriver for BuildahDriver {
     fn build(opts: BuildOpts) -> Result<()> {
         trace!("BuildahDriver::build({opts:#?})");
 
+        if let Some(base_image) = &opts.base_image {
+            debug!("Pulling image {base_image}");
+            // Pull with retries to reduce the chance of network/server issues causing an early
+            // build failure:
+            Self::pull(
+                PullOpts::builder()
+                    .image(base_image)
+                    .maybe_platform(opts.platform)
+                    .retry_count(3)
+                    .privileged(opts.privileged)
+                    .build(),
+            )?;
+        }
+
         let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         let command = sudo_cmd!(
@@ -72,7 +86,6 @@ impl BuildDriver for BuildahDriver {
                 "--platform",
                 platform.to_string(),
             ],
-            "--pull=always",
             if !opts.squash => "--layers",
             if opts.squash => "--squash",
             match opts.cache_from.as_ref() {

--- a/process/drivers/docker_driver.rs
+++ b/process/drivers/docker_driver.rs
@@ -194,6 +194,20 @@ impl BuildDriver for DockerDriver {
     fn build(opts: BuildOpts) -> Result<()> {
         trace!("DockerDriver::build({opts:#?})");
 
+        if let Some(base_image) = &opts.base_image {
+            debug!("Pulling image {base_image}");
+            // Pull with retries to reduce the chance of network/server issues causing an early
+            // build failure:
+            Self::pull(
+                PullOpts::builder()
+                    .image(base_image)
+                    .maybe_platform(opts.platform)
+                    .retry_count(3)
+                    .privileged(opts.privileged)
+                    .build(),
+            )?;
+        }
+
         let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         if opts.squash {

--- a/process/drivers/opts/build.rs
+++ b/process/drivers/opts/build.rs
@@ -16,6 +16,9 @@ use super::CompressionType;
 pub struct BuildOpts<'scope> {
     pub image: &'scope ImageRef<'scope>,
 
+    /// Base image to pull before building
+    pub base_image: Option<&'scope Reference>,
+
     #[builder(default)]
     pub squash: bool,
 
@@ -111,8 +114,11 @@ pub struct ManifestPushOpts<'scope> {
 #[derive(Debug, Clone, Copy, Builder)]
 #[builder(derive(Debug, Clone))]
 pub struct BuildTagPushOpts<'scope> {
-    /// The base image name.
+    /// The image name.
     pub image: &'scope ImageRef<'scope>,
+
+    /// Base image to pull before building
+    pub base_image: Option<&'scope Reference>,
 
     /// The path to the Containerfile to build.
     pub containerfile: &'scope Path,

--- a/process/drivers/opts/post_build.rs
+++ b/process/drivers/opts/post_build.rs
@@ -1,6 +1,5 @@
 use blue_build_utils::{container::ImageRef, platform::Platform};
 use bon::Builder;
-use oci_client::Reference;
 
 use crate::drivers::PostBuild;
 
@@ -32,8 +31,8 @@ pub struct PostBuildDriverOpts<'scope> {
     /// Post-build hook (e.g. for rechunking)
     pub post_build: &'scope dyn PostBuild,
 
-    /// Base image to remove after building.
-    pub remove_base_image: Option<&'scope Reference>,
+    /// Whether to remove the base image after building
+    pub remove_base_image: bool,
 
     /// Whether to take a previous image into account.
     #[builder(default)]

--- a/process/drivers/podman_driver.rs
+++ b/process/drivers/podman_driver.rs
@@ -3,6 +3,7 @@ use std::{
     ops::Not,
     path::Path,
     process::{Command, ExitStatus, Stdio},
+    time::Duration,
 };
 
 use blue_build_utils::{
@@ -191,6 +192,20 @@ impl BuildDriver for PodmanDriver {
     fn build(opts: BuildOpts) -> Result<()> {
         trace!("PodmanDriver::build({opts:#?})");
 
+        if let Some(base_image) = opts.base_image {
+            debug!("Pulling image {base_image}");
+            // Pull with retries to reduce the chance of network/server issues causing an early
+            // build failure:
+            Self::pull(
+                PullOpts::builder()
+                    .image(base_image)
+                    .maybe_platform(opts.platform)
+                    .retry_count(3)
+                    .privileged(opts.privileged)
+                    .build(),
+            )?;
+        }
+
         let temp_dir = tempdir().wrap_err("Failed to create temporary directory for secrets")?;
 
         let command = sudo_cmd!(
@@ -224,7 +239,6 @@ impl BuildDriver for PodmanDriver {
                 ],
                 _ => [],
             },
-            "--pull=always",
             if opts.host_network => "--net=host",
             if !opts.squash => "--layers",
             if opts.squash => "--squash",
@@ -348,18 +362,22 @@ impl BuildDriver for PodmanDriver {
         info!("Pulling image {image_str}...");
 
         trace!("{command:?}");
-        let output = blue_build_utils::retry(opts.retry_count.unwrap_or(1), 5, || {
-            let output = command.output().into_diagnostic()?;
-            if !output.status.success() {
-                let err_out = String::from_utf8_lossy(&output.stderr);
-                bail!(
-                    "Failed to pull image {}:\n{}",
-                    image_str.bold().red(),
-                    err_out
-                );
-            }
-            Ok(output)
-        })?;
+        let output = blue_build_utils::retry(
+            opts.retry_count.unwrap_or(1),
+            Duration::from_secs(5),
+            || {
+                let output = command.output().into_diagnostic()?;
+                if !output.status.success() {
+                    let err_out = String::from_utf8_lossy(&output.stderr);
+                    bail!(
+                        "Failed to pull image {}:\n{}",
+                        image_str.bold().red(),
+                        err_out
+                    );
+                }
+                Ok(output)
+            },
+        )?;
         info!("Successfully pulled image {}", image_str.bold().green());
         let container_id = {
             let mut stdout = output.stdout;
@@ -534,7 +552,9 @@ impl PostBuildDriver for PodmanDriver {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        if let Some(base_image) = pb_opts.remove_base_image {
+        if pb_opts.remove_base_image
+            && let Some(base_image) = opts.base_image
+        {
             Self::remove_image(
                 RemoveImageOpts::builder()
                     .image(base_image)
@@ -625,8 +645,8 @@ impl PostBuildDriver for PodmanDriver {
                     if opts.push {
                         let retry_count = if opts.retry_push { opts.retry_count } else { 0 };
 
-                        // Push images with retries (1s delay between retries)
-                        blue_build_utils::retry(retry_count, 5, || {
+                        // Push images with retries
+                        blue_build_utils::retry(retry_count, Duration::from_secs(5), || {
                             debug!("Pushing image {tagged_image}");
 
                             Self::manifest_push_with_layer_annotation_bug_workaround(

--- a/process/drivers/sigstore_driver.rs
+++ b/process/drivers/sigstore_driver.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path, time::Duration};
 
 use crate::{
     ASYNC_RUNTIME,
@@ -217,15 +217,16 @@ impl SigningDriver for SigstoreDriver {
 
         debug!("Triangulating image");
         let auth = Auth::Anonymous;
-        let (cosign_signature_image, source_image_digest) = retry(2, 5, || {
-            ASYNC_RUNTIME
-                .block_on(client.triangulate(&image_digest, &auth))
-                .into_diagnostic()
-                .with_context(|| format!("Failed to triangulate image {image_digest}"))
-        })?;
+        let (cosign_signature_image, source_image_digest) =
+            retry(2, Duration::from_secs(5), || {
+                ASYNC_RUNTIME
+                    .block_on(client.triangulate(&image_digest, &auth))
+                    .into_diagnostic()
+                    .with_context(|| format!("Failed to triangulate image {image_digest}"))
+            })?;
         trace!("{cosign_signature_image}, {source_image_digest}");
 
-        let trusted_layers = retry(2, 5, || {
+        let trusted_layers = retry(2, Duration::from_secs(5), || {
             ASYNC_RUNTIME
                 .block_on(client.trusted_signature_layers(
                     &auth,

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -4,6 +4,7 @@ use std::{
     ops::Not,
     path::PathBuf,
     process::{ExitStatus, Output},
+    time::Duration,
 };
 
 use blue_build_utils::{
@@ -179,6 +180,7 @@ pub trait BuildDriver: ImageStorageDriver {
 
         let build_opts_base = BuildOpts::builder()
             .containerfile(opts.containerfile.as_ref())
+            .maybe_base_image(opts.base_image)
             .squash(opts.squash)
             .maybe_cache_from(opts.cache_from)
             .maybe_cache_to(opts.cache_to)
@@ -227,8 +229,8 @@ pub trait BuildDriver: ImageStorageDriver {
                     if opts.push {
                         let retry_count = if opts.retry_push { opts.retry_count } else { 0 };
 
-                        // Push images with retries (1s delay between retries)
-                        blue_build_utils::retry(retry_count, 5, || {
+                        // Push images with retries
+                        blue_build_utils::retry(retry_count, Duration::from_secs(5), || {
                             debug!("Pushing image {tagged_image}");
 
                             Self::manifest_push(
@@ -601,8 +603,8 @@ pub trait BuildChunkedOciDriver: BuildDriver + ImageStorageDriver {
                             0
                         };
 
-                        // Push images with retries (1s delay between retries)
-                        blue_build_utils::retry(retry_count, 5, || {
+                        // Push images with retries
+                        blue_build_utils::retry(retry_count, Duration::from_secs(5), || {
                             debug!("Pushing image {tagged_image}");
 
                             // We push twice due to a (very strange) bug in podman where layer
@@ -762,7 +764,7 @@ pub trait RechunkDriver: RunDriver + BuildDriver + ContainerMountDriver {
                     tag.to_string(),
                 );
 
-                blue_build_utils::retry(opts.retry_count, 5, || {
+                blue_build_utils::retry(opts.retry_count, Duration::from_secs(5), || {
                     debug!("Pushing image {tagged_image}");
 
                     Driver.copy_oci(
@@ -1034,7 +1036,7 @@ pub trait SigningDriver: PrivateDriver {
 
         let retry_count = if opts.retry_push { opts.retry_count } else { 0 };
 
-        retry(retry_count, 5, || {
+        retry(retry_count, Duration::from_secs(5), || {
             Self::sign(sign_opts)?;
             Self::verify(verify_opts)
         })?;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -376,8 +376,16 @@ impl BuildCommand {
             },
         );
 
+        let base_image = recipe.base_image_ref()?;
+        let base_digest =
+            Driver::get_metadata(GetMetadataOpts::builder().image(&base_image).build())?
+                .digest()
+                .to_owned();
+        let base_image_with_digest = base_image.clone_with_digest(base_digest);
+
         let build_tag_opts = BuildTagPushOpts::builder()
             .image(&image_ref)
+            .base_image(&base_image_with_digest)
             .containerfile(containerfile)
             .platform(platforms)
             .squash(self.squash)
@@ -398,15 +406,6 @@ impl BuildCommand {
         };
 
         let images = if self.chunkah {
-            let base_image = recipe.base_image_ref()?;
-            let base_digest =
-                Driver::get_metadata(GetMetadataOpts::builder().image(&base_image).build())?
-                    .digest()
-                    .to_owned();
-            let remove_base_image = self
-                .remove_base_image
-                .then_some(base_image.clone_with_digest(base_digest));
-
             let (chunkah_tag, chunkah_digest) =
                 self.chunkah_version
                     .as_deref()
@@ -432,7 +431,7 @@ impl BuildCommand {
                 opts,
                 PostBuildDriverOpts::builder()
                     .post_build(&post_build)
-                    .maybe_remove_base_image(remove_base_image.as_ref())
+                    .remove_base_image(self.remove_base_image)
                     .use_previous_image(!self.rechunk_clear_plan)
                     .build(),
             )?

--- a/src/commands/validate/schema_validator.rs
+++ b/src/commands/validate/schema_validator.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashSet,
     path::Path,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 use blue_build_process_management::ASYNC_RUNTIME;
@@ -344,25 +345,29 @@ async fn cache_retrieve(uri: &Uri<String>) -> miette::Result<Value> {
         let client = reqwest::Client::new();
 
         log::debug!("Retrieving schema from {}", uri.bold().italic());
-        tokio::spawn(blue_build_utils::retry_async(3, 2, async move || {
-            let response = client
-                .get(&*uri)
-                .timeout(std::time::Duration::from_secs(10))
-                .send()
-                .await
-                .into_diagnostic()
-                .with_context(|| format!("Failed to retrieve schema from {uri}"))?;
-            let raw_output = response.bytes().await.into_diagnostic()?;
-            serde_json::from_slice(&raw_output)
-                .into_diagnostic()
-                .with_context(|| {
-                    format!(
-                        "Failed to parse json from {uri}, contents:\n{}",
-                        String::from_utf8_lossy(&raw_output)
-                    )
-                })
-                .inspect(|value| trace!("{}:\n{value}", uri.bold().italic()))
-        }))
+        tokio::spawn(blue_build_utils::retry_async(
+            3,
+            Duration::from_secs(2),
+            async move || {
+                let response = client
+                    .get(&*uri)
+                    .timeout(std::time::Duration::from_secs(10))
+                    .send()
+                    .await
+                    .into_diagnostic()
+                    .with_context(|| format!("Failed to retrieve schema from {uri}"))?;
+                let raw_output = response.bytes().await.into_diagnostic()?;
+                serde_json::from_slice(&raw_output)
+                    .into_diagnostic()
+                    .with_context(|| {
+                        format!(
+                            "Failed to parse json from {uri}, contents:\n{}",
+                            String::from_utf8_lossy(&raw_output)
+                        )
+                    })
+                    .inspect(|value| trace!("{}:\n{value}", uri.bold().italic()))
+            },
+        ))
         .await
         .expect("Should join task")
     }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -33,6 +33,7 @@ serde.workspace = true
 serde_yaml.workspace = true
 syntect.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["time"] }
 uuid.workspace = true
 which.workspace = true
 zeroize.workspace = true

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -18,7 +18,6 @@ use std::{
     ops::{AsyncFnMut, Not},
     os::unix::{ffi::OsStrExt, fs::PermissionsExt},
     path::{Path, PathBuf},
-    thread,
     time::Duration,
 };
 
@@ -58,11 +57,11 @@ pub fn check_command_exists(command: &str) -> Result<()> {
     }
 }
 
-/// Performs a retry on a given closure with a given nubmer of attempts and delay.
+/// Performs a retry on a given closure with a given number of attempts and delay.
 ///
 /// # Errors
 /// Will error when retries have been expended.
-pub fn retry<V, F>(mut retries: u8, delay_secs: u64, mut f: F) -> miette::Result<V>
+pub fn retry<V, F>(mut retries: u8, delay: Duration, mut f: F) -> miette::Result<V>
 where
     F: FnMut() -> miette::Result<V> + Send,
 {
@@ -73,17 +72,17 @@ where
             Err(e) => {
                 retries -= 1;
                 warn!("Failed operation, will retry {retries} more time(s). Error:\n{e:?}");
-                thread::sleep(Duration::from_secs(delay_secs));
+                std::thread::sleep(delay);
             }
         }
     }
 }
 
-/// Performs a retry on a given closure with a given nubmer of attempts and delay.
+/// Performs a retry on a given async closure with a given number of attempts and delay.
 ///
 /// # Errors
 /// Will error when retries have been expended.
-pub async fn retry_async<V, F>(mut retries: u8, delay_secs: u64, mut f: F) -> miette::Result<V>
+pub async fn retry_async<V, F>(mut retries: u8, delay: Duration, mut f: F) -> miette::Result<V>
 where
     F: AsyncFnMut() -> miette::Result<V>,
 {
@@ -94,7 +93,7 @@ where
             Err(e) => {
                 retries -= 1;
                 warn!("Failed operation, will retry {retries} more time(s). Error:\n{e:?}");
-                thread::sleep(Duration::from_secs(delay_secs));
+                tokio::time::sleep(delay).await;
             }
         }
     }


### PR DESCRIPTION
This should reduce the frequency of build failures caused by network/server issues when pulling a remote image before building.

Additionally, improve the retry utility functions:
* Make the retry functions accept a `Duration` rather than a `u64` representing seconds. This makes it clear at the call site that the argument represents a duration.
* Make `retry_async` use `tokio::time::sleep` instead of the blocking `std::thread::sleep`. Async functions shouldn't block for an extended period of time.