### PR TITLE
feat(chunkah): set SOURCE_DATE_EPOCH=0 for reproducibility

### DIFF
--- a/process/drivers/post_build/chunkah.rs
+++ b/process/drivers/post_build/chunkah.rs
@@ -119,6 +119,8 @@ impl PostBuildRunner for ChunkahRunner {
                 ),
                 "--volume",
                 format!("{path}:{path}:Z", path = chunkah_temp_dir.path().display()),
+                "--env",
+                "SOURCE_DATE_EPOCH=0", // for reproducibility
                 "--",
                 &self.chunkah_image_id,
                 "build",


### PR DESCRIPTION
This ensures file modification timestamps are all set to the Unix epoch, which means layers with identical file contents will have identical digests.