### PR TITLE
fix(chunkah): revert setting SOURCE_DATE_EPOCH=0

### DIFF
--- a/process/drivers/post_build/chunkah.rs
+++ b/process/drivers/post_build/chunkah.rs
@@ -119,8 +119,6 @@ impl PostBuildRunner for ChunkahRunner {
                 ),
                 "--volume",
                 format!("{path}:{path}:Z", path = chunkah_temp_dir.path().display()),
-                "--env",
-                "SOURCE_DATE_EPOCH=0", // for reproducibility
                 "--",
                 &self.chunkah_image_id,
                 "build",


### PR DESCRIPTION
Unfortunately, it seems that `SOURCE_DATE_EPOCH` is also used as the "current time" in package stability calculations, so setting that to a long time ago results in all package stability data being lost.

This reverts commit 280323ce305737107fd2fd4496417c6a896b2e8c.