### PR TITLE
fix(arm64): Fix arm64 test case

### DIFF
--- a/integration-tests/test-repo/recipes/arm-common.yml
+++ b/integration-tests/test-repo/recipes/arm-common.yml
@@ -1,0 +1,144 @@
+modules:
+  - from-file: akmods.yml
+  - from-file: flatpaks.yml
+
+  - type: files
+    files:
+      - source: usr
+        destination: /usr
+
+  - type: script
+    scripts:
+      - example.sh
+
+  - type: script
+    snippets:
+      - '[ -z "${TEST_ARG:-}" ]'
+
+  - type: script
+    env:
+      TEST_ARG: "test"
+    snippets:
+      - '[ "$TEST_ARG" = "test" ]'
+
+  - type: script
+    snippets:
+      - '[ -z "${TEST_ARG:-}" ]'
+
+  - type: dnf
+    repos:
+      files:
+        - https://copr.fedorainfracloud.org/coprs/atim/starship/repo/fedora-%OS_VERSION%/atim-starship-fedora-%OS_VERSION%.repo
+    install:
+      packages:
+        - micro
+        - starship
+    remove:
+      packages:
+        - firefox
+        - firefox-langpacks
+
+  - type: signing
+
+  - type: test-module
+    source: local
+
+  - type: test-nu-modules
+    source: local
+    test-prop:
+      - this
+      - is
+      - a
+      - test
+
+  - type: containerfile
+    containerfiles:
+      - labels
+    snippets:
+      - RUN echo "This is a snippet"
+
+  - type: copy
+    from: alpine-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: ubuntu-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: debian-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: fedora-test
+    src: /test.txt
+    dest: /
+  - type: copy
+    from: suse-test
+    src: /test.txt
+    dest: /
+
+  # Testing secrets
+  - type: script
+    secrets:
+      - type: env
+        name: TEST_SECRET
+        mount:
+          type: env
+          name: TEST_SECRET
+    snippets:
+      - '[ "$TEST_SECRET" == "test123" ]'
+
+  - type: script
+    secrets:
+      - type: env
+        name: TEST_SECRET
+        mount:
+          type: file
+          destination: /tmp/test-secret
+    snippets:
+      - '[ "$(cat /tmp/test-secret)" == "test123" ]'
+
+  - type: script
+    secrets:
+      - type: file
+        source: ./secrets/test-secret
+        mount:
+          type: file
+          destination: /tmp/test-secret
+    snippets:
+      - '[ "$(cat /tmp/test-secret)" == "321tset" ]'
+
+  - type: script
+    secrets:
+      - type: file
+        source: ./secrets/test-secret
+        mount:
+          type: env
+          name: TEST_SECRET
+    snippets:
+      - '[ "$TEST_SECRET" == "321tset" ]'
+
+  - type: script
+    secrets:
+      - type: exec
+        command: cat
+        args:
+          - ./test_secret_file.txt
+        mount:
+          type: env
+          name: TEST_SECRET
+    snippets:
+      - '[ "$TEST_SECRET" == "TEST_PASS" ]'
+
+  - type: script
+    secrets:
+      - type: exec
+        command: cat
+        args:
+          - ./test_secret_file.txt
+        mount:
+          type: file
+          destination: /tmp/test-secret
+    snippets:
+      - '[ "$(cat /tmp/test-secret)" == "TEST_PASS" ]'

--- a/integration-tests/test-repo/recipes/arm-stages.yml
+++ b/integration-tests/test-repo/recipes/arm-stages.yml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://schema.blue-build.org/module-stage-list-v1.json
+stages:
+  - name: ubuntu-test
+    from: docker.io/library/ubuntu
+    modules:
+      - from-file: stages.yml
+      - type: apt
+        install:
+          packages:
+            - git
+  - name: debian-test
+    from: docker.io/library/debian
+    modules:
+      - from-file: stages.yml
+      - type: apt
+        install:
+          packages:
+            - git
+  - name: fedora-test
+    from: docker.io/library/fedora
+    modules:
+      - from-file: stages.yml
+      - type: dnf
+        install:
+          packages:
+            - git
+  - name: alpine-test
+    from: docker.io/library/alpine
+    modules:
+      - from-file: stages.yml
+      - type: apk
+        install:
+          packages:
+            - git
+  - name: suse-test
+    from: docker.io/opensuse/tumbleweed
+    modules:
+      - from-file: stages.yml
+      - type: zypper
+        install:
+          packages:
+            - git
+modules:
+  - type: files
+    files:
+      - source: usr
+        destination: /usr
+  - type: script
+    scripts:
+      - example.sh
+    snippets:
+      - echo "test" > /test.txt
+  - type: test-module
+    source: local
+  - type: containerfile
+    containerfiles:
+      - labels
+    snippets:
+      - RUN echo "This is a snippet"
+  - type: test-nu-modules
+    source: local
+    test-prop:
+      - this
+      - is
+      - a
+      - test

--- a/integration-tests/test-repo/recipes/recipe-arm64.yml
+++ b/integration-tests/test-repo/recipes/recipe-arm64.yml
@@ -4,7 +4,9 @@ name: cli/test-arm64
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest
+platforms:
+  - linux/arm64
 stages:
-  - from-file: stages.yml
+  - from-file: arm-stages.yml
 modules:
-  - from-file: common.yml
+  - from-file: arm-common.yml


### PR DESCRIPTION
The issue was because Arch doesn't have an arm64 variant. I created a separate set of recipes for arm so that the test will FINALLY stop failing.