### PR TITLE
fix: Adjust parsing to handle buildkit changes

### DIFF
--- a/process/drivers/oci_client_driver.rs
+++ b/process/drivers/oci_client_driver.rs
@@ -1,7 +1,7 @@
 use blue_build_utils::credentials::Credentials;
 use cached::cached;
-use log::trace;
-use miette::{IntoDiagnostic, Result};
+use log::{debug, trace};
+use miette::{Context, IntoDiagnostic, Result};
 use oci_client::{Reference, client::ClientConfig, manifest::OciManifest, secrets::RegistryAuth};
 
 use crate::{
@@ -20,19 +20,36 @@ impl InspectDriver for OciClientDriver {
             let client = oci_client::Client::new(ClientConfig::default());
             let auth = match Credentials::get(image.registry()) {
                 Some(Credentials::Basic { username, password }) => {
+                    debug!("Using basic auth");
                     RegistryAuth::Basic(username, password.value().into())
                 }
-                Some(Credentials::Token(token)) => RegistryAuth::Bearer(token.value().into()),
-                None => RegistryAuth::Anonymous,
+                Some(Credentials::Token(token)) => {
+                    debug!("Using bearer token");
+                    RegistryAuth::Bearer(token.value().into())
+                }
+                None => {
+                    debug!("No auth");
+                    RegistryAuth::Anonymous
+                }
             };
 
             let (manifest, digest) = ASYNC_RUNTIME
                 .block_on(client.pull_manifest(image, &auth))
-                .into_diagnostic()?;
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to pull the manifest for {image}"))?;
+            debug!("Found OciManifest for {image}");
+            trace!("digest: {digest}");
+            trace!("{manifest:#?}");
 
             let manifest_digests = match &manifest {
-                OciManifest::Image(_) => vec![&digest],
+                OciManifest::Image(manifest) => {
+                    debug!("Found single image manifest for {image}");
+                    trace!("{manifest}");
+                    vec![&digest]
+                }
                 OciManifest::ImageIndex(index) => {
+                    debug!("Found image index for {image}");
+                    trace!("{index}");
                     index.manifests.iter().map(|entry| &entry.digest).collect()
                 }
             };
@@ -43,23 +60,49 @@ impl InspectDriver for OciClientDriver {
                 .into_iter()
                 .map(|digest| {
                     let image = &image.clone_with_digest(digest.clone());
-                    let (image_manifest, _) = ASYNC_RUNTIME
+                    let (image_manifest, image_manifest_digest) = ASYNC_RUNTIME
                         .block_on(client.pull_image_manifest(image, &auth))
-                        .into_diagnostic()?;
+                        .into_diagnostic()
+                        .wrap_err_with(|| format!("Failed to pull image manifest for {image}"))?;
+                    debug!("Pulled image manifest for {image}");
+                    trace!("digest: {image_manifest_digest}");
+                    trace!("{image_manifest:#?}");
 
                     let config = {
-                        let mut c: Vec<u8> = vec![];
+                        let capacity = image_manifest.config.size;
+                        let mut c: Vec<u8> = Vec::with_capacity(
+                            capacity.try_into().into_diagnostic().wrap_err_with(|| {
+                                format!(
+                                    concat!(
+                                        "Size of image {image} config ",
+                                        "({capacity}) could not be converted to usize"
+                                    ),
+                                    image = image,
+                                    capacity = capacity
+                                )
+                            })?,
+                        );
                         ASYNC_RUNTIME
                             .block_on(client.pull_blob(image, &image_manifest.config, &mut c))
-                            .into_diagnostic()?;
+                            .into_diagnostic()
+                            .wrap_err_with(|| format!("Failed to pull blob for {image}"))?;
                         c
                     };
                     Ok((
                         image_manifest.config.digest,
-                        serde_json::from_slice(&config).into_diagnostic()?,
+                        serde_json::from_slice(&config)
+                            .inspect(|config| trace!("{config:#?}"))
+                            .into_diagnostic()
+                            .wrap_err_with(|| {
+                                format!(
+                                    "Failed to convert config for {image} to ImageConfig:\n{}",
+                                    String::from_utf8_lossy(&config)
+                                )
+                            })?,
                     ))
                 })
                 .collect::<Result<Vec<_>>>()?;
+            debug!("Retrieved configs for {image}");
 
             trace!(
                 "Config digests: {:#?}",

--- a/process/drivers/traits.rs
+++ b/process/drivers/traits.rs
@@ -997,11 +997,16 @@ pub trait SigningDriver: PrivateDriver {
                 .no_cache(true)
                 .build(),
         )?;
+        debug!("Recieved metadata");
+        trace!("{metadata:#?}");
+
         let image_digest = Reference::with_digest(
             opts.image.resolve_registry().into(),
             opts.image.repository().into(),
             metadata.digest().into(),
         );
+        trace!("{image_digest}");
+
         let issuer = Driver::oidc_provider();
         let identity = Driver::keyless_cert_identity();
         let priv_key = PrivateKey::new(&path);

--- a/process/drivers/types/metadata.rs
+++ b/process/drivers/types/metadata.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct ImageConfig {
-    config: Config,
+    config: Option<Config>,
 }
 
 #[derive(Debug, Clone, Builder)]
@@ -53,7 +53,14 @@ impl ImageMetadata {
     pub fn get_version(&self) -> Result<Version> {
         self.configs
             .iter()
-            .find_map(|(_, config)| config.config.labels.as_ref()?.get(IMAGE_VERSION_LABEL))
+            .find_map(|(_, config)| {
+                config
+                    .config
+                    .as_ref()?
+                    .labels
+                    .as_ref()?
+                    .get(IMAGE_VERSION_LABEL)
+            })
             .ok_or_else(|| miette!("No version label found"))
             .and_then(|v| {
                 v.parse::<Version>()

--- a/process/logging.rs
+++ b/process/logging.rs
@@ -281,7 +281,7 @@ impl Encode for CustomPatternEncoder {
         if record.module_path().is_some_and(|mp| {
             self.filter_modules
                 .iter()
-                .any(|(module, level)| mp.contains(module) && *level <= record.level())
+                .any(|(module, level)| mp.starts_with(module) && *level <= record.level())
         }) {
             Ok(())
         } else {


### PR DESCRIPTION
There appears to have been a change in Buildkit that pushes an empty (`{}`) config in its manifest. This was causing a serde deserializing error due to the fact that `ImageConfig` in `process/drivers/types/metadata.rs` had `config` set without `Option`. Making that field optional appears to have fixed it.

In the process of trying to find the source of this bug, I noticed that the log handler was improperly filtering modules. That was updated to filter with `starts_with` instead of `contains`. I also added multiple lines of `debug!` and `trace!` logs for easier diagnosis in the future.