### PR TITLE
chore: Migrate to EarthBuild v0.8.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       packages: write # write pacakges to ghcr
 
     steps:
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -48,7 +48,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earthly --ci --push -P +prebuild
+          earth --ci --push -P +prebuild
 
   amd64-prebuild:
     timeout-minutes: 20
@@ -57,7 +57,7 @@ jobs:
       packages: write # write pacakges to ghcr
 
     steps:
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -81,7 +81,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earthly --ci --push -P +prebuild
+          earth --ci --push -P +prebuild
 
   build-images:
     permissions:
@@ -100,7 +100,7 @@ jobs:
         with:
           skip-if-available: "64G"
 
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -130,12 +130,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
-          earthly \
+          earth \
             --secret COSIGN_PRIVATE_KEY \
             --secret GH_ACTOR \
             --secret GH_TOKEN \
             --push --ci -P +build-images-all
-          earthly \
+          earth \
             --artifact +sign-all/digest-list ./digest-list
 
       - name: Store image digest info

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,4 +1,4 @@
-name: Earthly tag +build
+name: Earth tag +build
 
 permissions: {}
 
@@ -22,7 +22,7 @@ jobs:
       packages: write # write pacakges to ghcr
 
     steps:
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -43,7 +43,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earthly --ci --push -P +prebuild
+          earth --ci --push -P +prebuild
 
   amd64-prebuild:
     timeout-minutes: 60
@@ -52,7 +52,7 @@ jobs:
       packages: write # write pacakges to ghcr
 
     steps:
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -73,7 +73,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earthly --ci --push -P +prebuild
+          earth --ci --push -P +prebuild
 
   build-images:
     permissions:
@@ -100,7 +100,7 @@ jobs:
           fetch-tags: true
 
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
       - name: Set up QEMU
@@ -122,11 +122,11 @@ jobs:
           LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
           CARGO_PACKAGE_VERSION="v$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "blue-build") .version')"
           LATEST=$(test "$CARGO_PACKAGE_VERSION" = "$LATEST_TAG" && echo true || echo false)
-          earthly --secret COSIGN_PRIVATE_KEY \
+          earth --secret COSIGN_PRIVATE_KEY \
             --secret GH_ACTOR --secret GH_TOKEN \
             --push --ci -P +build-images-all \
             --TAGGED="true" --LATEST="$LATEST"
-          earthly \
+          earth \
             --artifact +sign-all/digest-list ./digest-list \
             --TAGGED="true" --LATEST="$LATEST"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -40,14 +40,14 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earthly --ci +test
+          earth --ci +test
 
   lint:
     timeout-minutes: 40
     runs-on: ubuntu-latest
 
     steps:
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -62,7 +62,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earthly --ci +lint
+          earth --ci +lint
 
   integration-tests:
     permissions:
@@ -76,7 +76,7 @@ jobs:
         with:
           skip-if-available: "64G"
 
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -91,8 +91,8 @@ jobs:
 
       - name: Run integration tests
         run: |
-          earthly bootstrap
-          earthly --ci -P ./integration-tests+all
+          earth bootstrap
+          earth --ci -P ./integration-tests+all
 
   docker-build:
     timeout-minutes: 60
@@ -954,7 +954,7 @@ jobs:
         with:
           skip-if-available: "64G"
 
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -993,7 +993,7 @@ jobs:
         with:
           skip-if-available: "64G"
 
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -1032,7 +1032,7 @@ jobs:
         with:
           skip-if-available: "64G"
 
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 
@@ -1071,7 +1071,7 @@ jobs:
         with:
           skip-if-available: "64G"
 
-      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,6 @@
 VERSION 0.8
-PROJECT blue-build/cli
 
 IMPORT github.com/blue-build/earthly-lib/rust AS rust
-# IMPORT ../earthly-lib/rust AS rust
 
 FROM alpine
 ARG --global IMAGE=ghcr.io/blue-build/cli
@@ -25,8 +23,8 @@ build-images-all:
         BUILD --platform=linux/amd64 --platform=linux/arm64 +build-images
     END
 
-    ARG EARTHLY_PUSH
-    IF [ "$EARTHLY_PUSH" = "true" ]
+    ARG EARTH_PUSH
+    IF [ "$EARTH_PUSH" = "true" ]
         BUILD --pass-args +sign-all
     END
 
@@ -190,9 +188,9 @@ blue-build-cli-prebuild:
 
     ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-    ARG EARTHLY_GIT_HASH
+    ARG EARTH_GIT_HASH
     ARG TARGETARCH
-    SAVE IMAGE --push "$IMAGE:$EARTHLY_GIT_HASH-prebuild-$TARGETARCH"
+    SAVE IMAGE --push "$IMAGE:$EARTH_GIT_HASH-prebuild-$TARGETARCH"
 
 blue-build-cli:
     FROM alpine
@@ -200,8 +198,8 @@ blue-build-cli:
     ARG TARGETARCH
 
     IF [ "$RELEASE" = "true" ]
-        ARG EARTHLY_GIT_HASH
-        FROM "$IMAGE:$EARTHLY_GIT_HASH-prebuild-$TARGETARCH"
+        ARG EARTH_GIT_HASH
+        FROM "$IMAGE:$EARTH_GIT_HASH-prebuild-$TARGETARCH"
     ELSE
         FROM +blue-build-cli-prebuild
     END
@@ -237,14 +235,14 @@ blue-build-cli-distrobox-prebuild:
 
     COPY +cosign/cosign /usr/bin/cosign
 
-    ARG EARTHLY_GIT_HASH
+    ARG EARTH_GIT_HASH
     ARG TARGETARCH
-    SAVE IMAGE --push "$IMAGE:$EARTHLY_GIT_HASH-distrobox-prebuild-$TARGETARCH"
+    SAVE IMAGE --push "$IMAGE:$EARTH_GIT_HASH-distrobox-prebuild-$TARGETARCH"
 
 blue-build-cli-distrobox:
-    ARG EARTHLY_GIT_HASH
+    ARG EARTH_GIT_HASH
     ARG TARGETARCH
-    FROM "$IMAGE:$EARTHLY_GIT_HASH-distrobox-prebuild-$TARGETARCH"
+    FROM "$IMAGE:$EARTH_GIT_HASH-distrobox-prebuild-$TARGETARCH"
 
     DO +INSTALL --OUT_DIR="/usr/bin/" --BUILD_TARGET="$(uname -m)-unknown-linux-musl"
 
@@ -307,8 +305,8 @@ digest-list:
     LET minor_version="$(echo "$version" | cut -d'.' -f2)"
 
     ARG --required SUFFIX_LIST
-    ARG EARTHLY_GIT_HASH
-    ARG EARTHLY_GIT_BRANCH
+    ARG EARTH_GIT_HASH
+    ARG EARTH_GIT_BRANCH
     LET suffix=""
 
     FOR s IN $SUFFIX_LIST
@@ -327,9 +325,9 @@ digest-list:
                 DO +PRINT_IMAGE_DIGEST --IMAGE="${IMAGE}:v${major_version}${suffix}"
             END
         ELSE
-            DO +PRINT_IMAGE_DIGEST --IMAGE="${IMAGE}:$(echo "${EARTHLY_GIT_BRANCH}" | sed 's|/|_|g')${suffix}"
+            DO +PRINT_IMAGE_DIGEST --IMAGE="${IMAGE}:$(echo "${EARTH_GIT_BRANCH}" | sed 's|/|_|g')${suffix}"
         END
-        DO +PRINT_IMAGE_DIGEST --IMAGE="${IMAGE}:${EARTHLY_GIT_HASH}${suffix}"
+        DO +PRINT_IMAGE_DIGEST --IMAGE="${IMAGE}:${EARTH_GIT_HASH}${suffix}"
     END
 
     SAVE ARTIFACT /digest-list
@@ -398,12 +396,12 @@ SAVE_IMAGE:
             SAVE IMAGE --push "${IMAGE}:v${major_version}${SUFFIX}"
         END
     ELSE
-        ARG EARTHLY_GIT_BRANCH
-        ARG IMAGE_TAG="$(echo "${EARTHLY_GIT_BRANCH}" | sed 's|/|_|g')"
+        ARG EARTH_GIT_BRANCH
+        ARG IMAGE_TAG="$(echo "${EARTH_GIT_BRANCH}" | sed 's|/|_|g')"
         SAVE IMAGE --push "${IMAGE}:${IMAGE_TAG}${SUFFIX}"
     END
-    ARG EARTHLY_GIT_HASH
-    SAVE IMAGE --push "${IMAGE}:${EARTHLY_GIT_HASH}${SUFFIX}"
+    ARG EARTH_GIT_HASH
+    SAVE IMAGE --push "${IMAGE}:${EARTH_GIT_HASH}${SUFFIX}"
 
 LABELS:
     FUNCTION
@@ -423,8 +421,8 @@ LABELS:
     LABEL org.opencontainers.image.documentation="https://raw.githubusercontent.com/blue-build/cli/main/README.md"
 
     IF [ "$TAGGED" = "true" ]
-        ARG EARTHLY_GIT_BRANCH
-        LABEL org.opencontainers.image.ref.name="$EARTHLY_GIT_BRANCH"
+        ARG EARTH_GIT_BRANCH
+        LABEL org.opencontainers.image.ref.name="$EARTH_GIT_BRANCH"
     ELSE
         LABEL org.opencontainers.image.ref.name="v$VERSION"
     END

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
-  
+
   description = "BlueBuild's command line program that builds Containerfiles and custom images";
 
-  
+
   inputs = {
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*.tar.gz";
 
@@ -14,7 +14,7 @@
     };
   };
 
-  
+
   outputs = { self, flake-schemas, nixpkgs, rust-overlay }:
     let
       overlays = [
@@ -23,13 +23,13 @@
           rustToolchain = (final.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override { extensions = [ "rust-src"]; };
         })
       ];
-      
+
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
       forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f rec {
         pkgs = import nixpkgs { inherit overlays system; };
         lib = pkgs.lib;
       });
-    in {      
+    in {
       schemas = flake-schemas.schemas;
 
       packages = forEachSupportedSystem ({ pkgs, lib }: rec {
@@ -48,10 +48,10 @@
           };
         };
       });
-      
+
       devShells = forEachSupportedSystem ({ pkgs, ... }: {
         default = pkgs.mkShell {
-          
+
           packages = with pkgs; [
             rustToolchain
             cargo-bloat
@@ -62,7 +62,7 @@
             cargo
             rustc
             bacon
-            earthly
+            earth
             jq
             nixpkgs-fmt
           ];

--- a/integration-tests/Earthfile
+++ b/integration-tests/Earthfile
@@ -1,7 +1,6 @@
 VERSION 0.8
-PROJECT blue-build/cli
 
-IMPORT github.com/earthly/lib/utils/dind AS dind
+IMPORT github.com/EarthBuild/lib/utils/dind AS dind
 
 all:
     BUILD +build
@@ -39,7 +38,7 @@ build-full:
     WITH DOCKER
         RUN --secret BB_PASSWORD=github/registry bluebuild build --push -S sigstore -vv recipes/recipe.yml
     END
-    
+
 switch:
     FROM +test-base
 

--- a/justfile
+++ b/justfile
@@ -20,8 +20,8 @@ clean: clean_container_build_scripts
   command -v podman \
     && podman system prune -f \
     || true
-  command -v earthly \
-    && earthly prune --reset \
+  command -v earth \
+    && earth prune --reset \
     || true
 
 # Cleans build scripts generated from container testing which can be root
@@ -105,7 +105,7 @@ release *args:
   #!/usr/bin/env bash
   set -euxo pipefail
 
-  earthly --ci +run-checks
+  earth --ci +run-checks
 
   # --workspace: updating all crates in the workspace
   # --no-tag: do not push tag for each new version
@@ -361,7 +361,7 @@ test-generate-iso-recipe: generate-test-secret install-debug-all-features
 
 # Build a local cli image
 build-local-cli-image:
-  earthly --ci --output -P +blue-build-cli --RELEASE='false'
+  earth --ci --output -P +blue-build-cli --RELEASE='false'
 
 git_sha := `git rev-parse HEAD`
 tty_arg := `[ -t 0 ] && echo "t" || echo ""`


### PR DESCRIPTION
Earthly builder development was stopped some time ago and has now been replaced by a community fork called [EarthBuild](https://github.com/EarthBuild). These changes migrates our build infrastructure to the new fork. The [latest release](https://github.com/EarthBuild/earthbuild/releases/tag/v0.8.18) has breaking changes as the CLI binary has been renamed and the built-in ARGs have also been renamed.