### PR TITLE
chore(cicd): Setup build system to work with forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       repo:
         required: true
         type: string
+      fork_pr:
+        default: false
+        type: boolean
     secrets:
       SIGNING_SECRET:
         required: true
@@ -27,15 +30,15 @@ jobs:
 
     steps:
       - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         with:
           use-cache: false
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -44,7 +47,7 @@ jobs:
 
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -52,7 +55,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Run build
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         id: build
         run: |
           just image-prebuild-publish
@@ -65,16 +68,16 @@ jobs:
 
     steps:
       - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         with:
           use-cache: false
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
 
       # Setup repo and add caching
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -84,7 +87,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -93,7 +96,7 @@ jobs:
 
       - name: Run build
         id: build
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         run: |
           just image-prebuild-publish
 
@@ -134,15 +137,14 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-
       - name: Run build
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         env:
           GH_ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
@@ -155,12 +157,12 @@ jobs:
           fi
 
       - name: Run build
-        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ inputs.fork_pr }}
         run: |
           just image-build
 
       - name: Store image digest info
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ ! inputs.fork_pr }}
         id: image_manifest_metadata
         run: |
           digest_list_json=$(jq -Rc '[ inputs | split(",") | {"image_ref":.[0],"image_digest":.[1]} ]' ./digest-list)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           use-cache: false
 
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -60,6 +62,8 @@ jobs:
       - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
         with:
           use-cache: false
+
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
       # Setup repo and add caching
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
   arm64-prebuild:
     timeout-minutes: 20
     runs-on: ubuntu-24.04-arm
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       packages: write # write pacakges to ghcr
 
@@ -55,6 +56,7 @@ jobs:
   amd64-prebuild:
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       packages: write # write pacakges to ghcr
 
@@ -124,6 +126,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -131,6 +134,7 @@ jobs:
 
 
       - name: Run build
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         env:
           GH_ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
@@ -142,13 +146,20 @@ jobs:
             just image-publish
           fi
 
+      - name: Run build
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          just image-build
+
       - name: Store image digest info
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         id: image_manifest_metadata
         run: |
           digest_list_json=$(jq -Rc '[ inputs | split(",") | {"image_ref":.[0],"image_digest":.[1]} ]' ./digest-list)
           echo "digests=$digest_list_json" >> $GITHUB_OUTPUT
 
   provenance:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [build-images]
     permissions:
       actions: read # for detecting the Github Actions environment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earth --ci --push -P +prebuild
+          just image-prebuild-publish
 
   amd64-prebuild:
     timeout-minutes: 20
@@ -81,7 +81,7 @@ jobs:
       - name: Run build
         id: build
         run: |
-          earth --ci --push -P +prebuild
+          just image-prebuild-publish
 
   build-images:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,20 @@ jobs:
   arm64-prebuild:
     timeout-minutes: 20
     runs-on: ubuntu-24.04-arm
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       packages: write # write pacakges to ghcr
 
     steps:
       - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           use-cache: false
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -42,6 +44,7 @@ jobs:
 
 
       - name: Login to GitHub Container Registry
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -49,6 +52,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Run build
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         id: build
         run: |
           just image-prebuild-publish
@@ -56,19 +60,21 @@ jobs:
   amd64-prebuild:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       packages: write # write pacakges to ghcr
 
     steps:
       - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           use-cache: false
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
       # Setup repo and add caching
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -78,6 +84,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -86,6 +93,7 @@ jobs:
 
       - name: Run build
         id: build
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           just image-prebuild-publish
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
       # Setup repo and add caching
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -130,13 +132,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
-          earth \
-            --secret COSIGN_PRIVATE_KEY \
-            --secret GH_ACTOR \
-            --secret GH_TOKEN \
-            --push --ci -P +build-images-all
-          earth \
-            --artifact +sign-all/digest-list ./digest-list
+          if [ -n "${COSIGN_PRIVATE_KEY}" ]; then
+            just image-sign-publish
+          else
+            just image-publish
+          fi
 
       - name: Store image digest info
         id: image_manifest_metadata

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
-    if: github.repository == 'blue-build/cli'
     permissions:
       contents: read # read repo contents
       packages: write # write package to ghcr

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
-    if: github.repository == 'blue-build/cli'
     permissions:
       contents: read # read repo contents
       packages: write # write package to ghcr
@@ -21,6 +20,7 @@ jobs:
     with:
       repo: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
+      fork_pr: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
   test:
@@ -33,5 +33,6 @@ jobs:
       repo: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
       pr_event_number: ${{ github.event.number }}
+      fork_pr: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -95,7 +95,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
           COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-          RUN_JUST_RECIPE: ${{ inputs.just_recipe }}
+          RUN_JUST_RECIPE: ${{ inputs.run }}
         run: just "${RUN_JUST_RECIPE}"
 
       - name: Run ${{ inputs.run }} Fork PR

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,108 @@
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      run:
+        required: true
+        type: string
+      pr_event_number:
+        type: string
+      fork_pr:
+        default: false
+        type: boolean
+      registry_login:
+        default: false
+        type: boolean
+      install_qemu:
+        default: false
+        type: boolean
+      install_docker:
+        default: false
+        type: boolean
+      install_earthbuild:
+        default: false
+        type: boolean
+    secrets:
+      TEST_SIGNING_SECRET:
+        required: true
+        description: The cosign private key used to sign images for tests
+env:
+  FORCE_COLOR: 1
+  CLICOLOR_FORCE: 1
+  RUST_LOG_STYLE: always
+
+permissions: {}
+
+jobs:
+  run-test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read repo contents
+      packages: write # write test package to ghcr
+      id-token: write # docker auth
+
+    steps:
+      - name: Maximize build space
+        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
+        with:
+          skip-if-available: "64G"
+
+      - name: Set up Docker Buildx
+        if: ${{ inputs.install_docker }}
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          install: true
+
+      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
+        if: ${{ inputs.install_earthbuild }}
+        with:
+          use-cache: false
+
+      - name: Set up QEMU
+        if: ${{ inputs.install_qemu }}
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: ${{ ! inputs.fork_pr && inputs.registry_login }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # Setup repo and add caching
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repo }}
+
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      - name: Run Build
+        if: ${{ ! inputs.fork_pr }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
+          RUN_JUST_RECIPE: ${{ inputs.just_recipe }}
+        run: just "${RUN_JUST_RECIPE}"
+
+      - name: Run Build Fork PR
+        if: ${{ inputs.fork_pr }}
+        env:
+          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
+          RUN_JUST_RECIPE: ${{ inputs.just_recipe }}
+        run: |
+          export CARGO_HOME=$HOME/.cargo
+          just "${RUN_JUST_RECIPE}"
+

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -40,6 +40,7 @@ permissions: {}
 
 jobs:
   run-test:
+    name: ${{ inputs.run }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -88,7 +88,7 @@ jobs:
 
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
-      - name: Run Build
+      - name: Run ${{ inputs.run }}
         if: ${{ ! inputs.fork_pr }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -97,11 +97,11 @@ jobs:
           RUN_JUST_RECIPE: ${{ inputs.just_recipe }}
         run: just "${RUN_JUST_RECIPE}"
 
-      - name: Run Build Fork PR
+      - name: Run ${{ inputs.run }} Fork PR
         if: ${{ inputs.fork_pr }}
         env:
           GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          RUN_JUST_RECIPE: ${{ inputs.just_recipe }}
+          RUN_JUST_RECIPE: ${{ inputs.run }}
         run: |
           export CARGO_HOME=$HOME/.cargo
           just "${RUN_JUST_RECIPE}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -841,6 +841,14 @@ jobs:
         with:
           install: true
 
+      - name: Docker Login
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: inputs.repo == 'blue-build/cli'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -881,6 +889,14 @@ jobs:
         with:
           install: true
 
+      - name: Docker Login
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: inputs.repo == 'blue-build/cli'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -920,6 +936,14 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           install: true
+
+      - name: Docker Login
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: inputs.repo == 'blue-build/cli'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
         type: string
       pr_event_number:
         type: string
+      fork_pr:
+        default: false
+        type: boolean
     secrets:
       TEST_SIGNING_SECRET:
         required: true
@@ -18,7 +21,10 @@ env:
   CLICOLOR_FORCE: 1
   RUST_LOG_STYLE: always
 
-permissions: {}
+permissions:
+  contents: read # read repo contents
+  packages: write # write test package to ghcr
+  id-token: write # docker auth
 
 jobs:
   test:
@@ -65,8 +71,6 @@ jobs:
           earth --ci +lint
 
   integration-tests:
-    permissions:
-      packages: write # needed to write integ test packages
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
@@ -95,1027 +99,290 @@ jobs:
           earth --ci -P ./integration-tests+all
 
   docker-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-docker-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_docker: true
+      run: test-docker-build
 
   recipe-v2:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-recipe-v2-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-recipe-v2-build
 
   empty-files-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-empty-files-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-empty-files-build
 
   env-expand-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-env-expansion-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-env-expansion-build
 
   bluefin-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-bluefin-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-bluefin-build
 
   chunkah-build:
-    timeout-minutes: 40
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          install-dir: /usr/bin
-          use-sudo: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: |
-          export CARGO_HOME=$HOME/.cargo
-          just test-chunkah-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-chunkah-build
 
   build-chunked-oci-build:
-    timeout-minutes: 40
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          install-dir: /usr/bin
-          use-sudo: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: |
-          export CARGO_HOME=$HOME/.cargo
-          just test-build-chunked-oci-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-build-chunked-oci-build
 
   rechunk-build:
-    timeout-minutes: 40
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          install-dir: /usr/bin
-          use-sudo: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: |
-          export CARGO_HOME=$HOME/.cargo
-          just test-fresh-rechunk-build
-          just test-rechunk-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-rechunk-build
 
   arm64-build:
-    timeout-minutes: 90
-    runs-on: ubuntu-24.04-arm
-    # runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-arm64-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-arm64-build
 
   docker-build-external-login:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - name: Docker Login
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: inputs.repo == 'blue-build/cli'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-docker-build-external-login
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      registry_login: true
+      install_docker: true
+      run: test-docker-build-external-login
 
   podman-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-podman-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-podman-build
 
   buildah-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      # Setup repo and add caching
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-buildah-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-buildah-build
 
   multi-platform-docker:
-    timeout-minutes: 90
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-multiplatform-docker
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_docker: true
+      install_qemu: true
+      run: test-multiplatform-docker
 
   multi-platform-podman:
-    timeout-minutes: 90
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-multiplatform-podman
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_qemu: true
+      run: test-multiplatform-podman
 
   multi-platform-buildah:
-    timeout-minutes: 90
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-multiplatform-buildah
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_qemu: true
+      run: test-multiplatform-buildah
 
   multi-platform-chunkah:
-    timeout-minutes: 120
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-multiplatform-chunkah
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_qemu: true
+      run: test-multiplatform-chunkah
 
   multi-platform-build-chunked-oci:
-    timeout-minutes: 120
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-multiplatform-build-chunked-oci
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_qemu: true
+      run: test-multiplatform-build-chunked-oci
 
   multi-platform-rechunk:
-    timeout-minutes: 120
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-multiplatform-rechunk
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_qemu: true
+      run: test-multiplatform-rechunk
 
   iso-from-image:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - name: Docker Login
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: inputs.repo == 'blue-build/cli'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-generate-iso-image
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-generate-iso-image
 
   iso-from-image-web-ui:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - name: Docker Login
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: inputs.repo == 'blue-build/cli'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-generate-iso-web-ui
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-generate-iso-web-ui
 
   iso-from-recipe:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - name: Docker Login
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        if: inputs.repo == 'blue-build/cli'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-generate-iso-image
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      run: test-generate-iso-image
 
   container-podman-build:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
-        with:
-          use-cache: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-container-podman-build
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_earthbuild: true
+      run: test-container-podman-build
 
   container-podman-chunkah:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
-        with:
-          use-cache: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-container-podman-chunkah
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_earthbuild: true
+      run: test-container-podman-chunkah
 
   container-podman-build-chunked-oci:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
-        with:
-          use-cache: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-container-podman-build-chunked-oci
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_earthbuild: true
+      run: test-container-podman-build-chunked-oci
 
   container-podman-rechunk:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # read repo contents
-      packages: write # write test package to ghcr
-      id-token: write # docker auth
-
-    steps:
-      - name: Maximize build space
-        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
-        with:
-          skip-if-available: "64G"
-
-      - uses: EarthBuild/actions-setup@f4d20223e70dbb43b5fc08c4d857ab9cf0dbf3ae # v2.2.0
-        with:
-          use-cache: false
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          install: true
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ inputs.ref }}
-          repository: ${{ inputs.repo }}
-
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-
-      - name: Run Build
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_PR_EVENT_NUMBER: ${{ inputs.pr_event_number }}
-          COSIGN_PRIVATE_KEY: ${{ secrets.TEST_SIGNING_SECRET }}
-        run: just test-container-podman-rechunk
+    uses: ./.github/workflows/run-test.yml
+    secrets:
+      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+    with:
+      repo: ${{ inputs.repo }}
+      ref: ${{ inputs.ref }}
+      fork_pr: ${{ inputs.fork_pr }}
+      pr_event_number: ${{ inputs.pr_event_number }}
+      install_earthbuild: true
+      run: test-container-podman-rechunk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
   docker-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -113,7 +113,7 @@ jobs:
   recipe-v2:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -124,7 +124,7 @@ jobs:
   empty-files-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -135,7 +135,7 @@ jobs:
   env-expand-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -146,7 +146,7 @@ jobs:
   bluefin-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -157,7 +157,7 @@ jobs:
   chunkah-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -168,7 +168,7 @@ jobs:
   build-chunked-oci-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -179,7 +179,7 @@ jobs:
   rechunk-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -190,7 +190,7 @@ jobs:
   arm64-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -201,7 +201,7 @@ jobs:
   docker-build-external-login:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -214,7 +214,7 @@ jobs:
   podman-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -225,7 +225,7 @@ jobs:
   buildah-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -236,7 +236,7 @@ jobs:
   multi-platform-docker:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -249,7 +249,7 @@ jobs:
   multi-platform-podman:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -261,7 +261,7 @@ jobs:
   multi-platform-buildah:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -273,7 +273,7 @@ jobs:
   multi-platform-chunkah:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -285,7 +285,7 @@ jobs:
   multi-platform-build-chunked-oci:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -297,7 +297,7 @@ jobs:
   multi-platform-rechunk:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -309,7 +309,7 @@ jobs:
   iso-from-image:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -320,7 +320,7 @@ jobs:
   iso-from-image-web-ui:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -331,7 +331,7 @@ jobs:
   iso-from-recipe:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -342,7 +342,7 @@ jobs:
   container-podman-build:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -354,7 +354,7 @@ jobs:
   container-podman-chunkah:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -366,7 +366,7 @@ jobs:
   container-podman-build-chunked-oci:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}
@@ -378,7 +378,7 @@ jobs:
   container-podman-rechunk:
     uses: ./.github/workflows/run-test.yml
     secrets:
-      SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
+      TEST_SIGNING_SECRET: ${{ secrets.TEST_SIGNING_SECRET }}
     with:
       repo: ${{ inputs.repo }}
       ref: ${{ inputs.ref }}

--- a/Earthfile
+++ b/Earthfile
@@ -5,6 +5,8 @@ IMPORT github.com/blue-build/earthly-lib/rust AS rust
 FROM alpine
 ARG --global SUFFIX_LIST="- distrobox installer"
 ARG --global EARTH_GIT_PROJECT_NAME
+ARG --global EARTH_GIT_HASH
+ARG --global EARTH_GIT_BRANCH
 ARG --global FEDORA_VERSION="44"
 ARG --global IMAGE="ghcr.io/${EARTH_GIT_PROJECT_NAME}"
 ARG --global TAGGED="false"
@@ -190,7 +192,6 @@ blue-build-cli-prebuild:
 
     ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
-    ARG EARTH_GIT_HASH
     ARG TARGETARCH
     SAVE IMAGE --push "$IMAGE:$EARTH_GIT_HASH-prebuild-$TARGETARCH"
 
@@ -200,7 +201,6 @@ blue-build-cli:
     ARG TARGETARCH
 
     IF [ "$RELEASE" = "true" ]
-        ARG EARTH_GIT_HASH
         FROM "$IMAGE:$EARTH_GIT_HASH-prebuild-$TARGETARCH"
     ELSE
         FROM +blue-build-cli-prebuild
@@ -237,17 +237,14 @@ blue-build-cli-distrobox-prebuild:
 
     COPY +cosign/cosign /usr/bin/cosign
 
-    ARG EARTH_GIT_HASH
     ARG TARGETARCH
     SAVE IMAGE --push "$IMAGE:$EARTH_GIT_HASH-distrobox-prebuild-$TARGETARCH"
 
 blue-build-cli-distrobox:
-    ARG EARTH_GIT_HASH
     ARG RELEASE
     ARG TARGETARCH
 
     IF [ "$RELEASE" = "true" ]
-        ARG EARTH_GIT_HASH
         FROM "$IMAGE:$EARTH_GIT_HASH-distrobox-prebuild-$TARGETARCH"
     ELSE
         FROM +blue-build-cli-distrobox-prebuild
@@ -320,8 +317,6 @@ digest-list:
     LET minor_version="$(echo "$version" | cut -d'.' -f2)"
 
     ARG --required SUFFIX_LIST
-    ARG EARTH_GIT_HASH
-    ARG EARTH_GIT_BRANCH
     LET suffix=""
 
     FOR s IN $SUFFIX_LIST
@@ -411,11 +406,9 @@ SAVE_IMAGE:
             SAVE IMAGE --push "${IMAGE}:v${major_version}${SUFFIX}"
         END
     ELSE
-        ARG EARTH_GIT_BRANCH
         ARG IMAGE_TAG="$(echo "${EARTH_GIT_BRANCH}" | sed 's|/|_|g')"
         SAVE IMAGE --push "${IMAGE}:${IMAGE_TAG}${SUFFIX}"
     END
-    ARG EARTH_GIT_HASH
     SAVE IMAGE --push "${IMAGE}:${EARTH_GIT_HASH}${SUFFIX}"
 
 LABELS:
@@ -436,7 +429,6 @@ LABELS:
     LABEL org.opencontainers.image.documentation="https://raw.githubusercontent.com/${EARTH_GIT_PROJECT_NAME}/main/README.md"
 
     IF [ "$TAGGED" = "true" ]
-        ARG EARTH_GIT_BRANCH
         LABEL org.opencontainers.image.ref.name="$EARTH_GIT_BRANCH"
     ELSE
         LABEL org.opencontainers.image.ref.name="v$VERSION"

--- a/Earthfile
+++ b/Earthfile
@@ -87,7 +87,7 @@ EACH_FEAT:
 install:
     FROM +common
     ARG --required BUILD_TARGET
-    ARG --required RELEASE
+    ARG RELEASE
 
     IF [ "$RELEASE" = "true" ]
         DO rust+CROSS --target="$BUILD_TARGET" --output="$BUILD_TARGET/release/[^\./]+"
@@ -100,7 +100,7 @@ install:
 install-all-features:
     FROM +common
     ARG --required BUILD_TARGET
-    ARG --required RELEASE
+    ARG RELEASE
 
     IF [ "$RELEASE" = "true" ]
         DO rust+CROSS --args="build --all-features --release" --target="$BUILD_TARGET" --output="$BUILD_TARGET/release/[^\./]+"

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,10 @@ VERSION 0.8
 IMPORT github.com/blue-build/earthly-lib/rust AS rust
 
 FROM alpine
-ARG --global IMAGE=ghcr.io/blue-build/cli
+ARG --global SUFFIX_LIST="- distrobox installer"
+ARG --global EARTH_GIT_PROJECT_NAME
+ARG --global FEDORA_VERSION="44"
+ARG --global IMAGE="ghcr.io/${EARTH_GIT_PROJECT_NAME}"
 ARG --global TAGGED="false"
 ARG --global LATEST="false"
 
@@ -24,13 +27,12 @@ build-images-all:
     END
 
     ARG EARTH_PUSH
-    IF [ "$EARTH_PUSH" = "true" ]
-        BUILD --pass-args +sign-all
+    ARG SIGN
+    IF [ "$EARTH_PUSH" = "true" ] && [ "$SIGN" = "true" ]
+        BUILD --pass-args +sign-images
     END
 
-sign-all:
-    ARG SUFFIX_LIST="- distrobox installer"
-    BUILD --pass-args +sign-images
+local-digest-list:
     COPY --pass-args +digest-list/digest-list /
     SAVE ARTIFACT /digest-list AS LOCAL ./digest-list
 
@@ -136,7 +138,7 @@ common:
     DO rust+INIT --keep_fingerprints=true
 
 blue-build-cli-prebuild:
-    ARG BASE_IMAGE="registry.fedoraproject.org/fedora-toolbox:42"
+    ARG BASE_IMAGE="registry.fedoraproject.org/fedora-toolbox:${FEDORA_VERSION}"
     FROM "$BASE_IMAGE"
 
     RUN dnf5 -y update \
@@ -194,7 +196,7 @@ blue-build-cli-prebuild:
 
 blue-build-cli:
     FROM alpine
-    ARG RELEASE="true"
+    ARG RELEASE
     ARG TARGETARCH
 
     IF [ "$RELEASE" = "true" ]
@@ -241,8 +243,15 @@ blue-build-cli-distrobox-prebuild:
 
 blue-build-cli-distrobox:
     ARG EARTH_GIT_HASH
+    ARG RELEASE
     ARG TARGETARCH
-    FROM "$IMAGE:$EARTH_GIT_HASH-distrobox-prebuild-$TARGETARCH"
+
+    IF [ "$RELEASE" = "true" ]
+        ARG EARTH_GIT_HASH
+        FROM "$IMAGE:$EARTH_GIT_HASH-distrobox-prebuild-$TARGETARCH"
+    ELSE
+        FROM +blue-build-cli-distrobox-prebuild
+    END
 
     DO +INSTALL --OUT_DIR="/usr/bin/" --BUILD_TARGET="$(uname -m)-unknown-linux-musl"
 
@@ -263,12 +272,18 @@ installer:
         DO +INSTALL --OUT_DIR="/out/" --BUILD_TARGET="x86_64-unknown-linux-musl"
     END
 
-    COPY install.sh /install.sh
+    COPY +modify-installer/install.sh /install.sh
 
     CMD ["cat", "/install.sh"]
 
     DO --pass-args +SAVE_IMAGE --SUFFIX="-installer"
     SAVE ARTIFACT /out/bluebuild
+
+modify-installer:
+    FROM --platform native alpine
+    COPY install.sh /install.sh
+    RUN sed -i "s|^PROJECT=\"blue-build/cli\"|PROJECT=\"${EARTH_GIT_PROJECT_NAME}\"|" /install.sh
+    SAVE ARTIFACT /install.sh
 
 cosign:
     FROM ghcr.io/sigstore/cosign/cosign:v3.1.3
@@ -407,8 +422,8 @@ LABELS:
     FUNCTION
     LET build_time="$(date -Iseconds)"
     LABEL org.opencontainers.image.created="$build_time"
-    LABEL org.opencontainers.image.url="https://github.com/blue-build/cli"
-    LABEL org.opencontainers.image.source="https://github.com/blue-build/cli"
+    LABEL org.opencontainers.image.url="https://github.com/${EARTH_GIT_PROJECT_NAME}"
+    LABEL org.opencontainers.image.source="https://github.com/${EARTH_GIT_PROJECT_NAME}"
     LABEL org.opencontainers.image.version="$VERSION"
     LABEL version="$VERSION"
     LABEL org.opencontainers.image.vendor="BlueBuild"
@@ -416,9 +431,9 @@ LABELS:
     LABEL org.opencontainers.image.licenses="Apache-2.0"
     LABEL license="Apache-2.0"
     LABEL org.opencontainers.image.title="BlueBuild CLI tool"
-    LABEL name="blue-build/cli"
+    LABEL name="${EARTH_GIT_PROJECT_NAME}"
     LABEL org.opencontainers.image.description="A CLI tool built for creating Containerfile templates for ostree based atomic distros"
-    LABEL org.opencontainers.image.documentation="https://raw.githubusercontent.com/blue-build/cli/main/README.md"
+    LABEL org.opencontainers.image.documentation="https://raw.githubusercontent.com/${EARTH_GIT_PROJECT_NAME}/main/README.md"
 
     IF [ "$TAGGED" = "true" ]
         ARG EARTH_GIT_BRANCH

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 VERSION=v0.9.37
+PROJECT="blue-build/cli"
 
 # Container runtime
 function cr() {
@@ -16,12 +17,11 @@ function cr() {
   fi
 }
 
-# We use sudo for podman so that we can copy directly into /usr/local/bin
 function cleanup() {
   echo "Cleaning up image"
   cr rm blue-build-installer
   sleep 2
-  cr image rm ghcr.io/blue-build/cli:${VERSION}-installer
+  cr image rm ghcr.io/${PROJECT}:${VERSION}-installer
 }
 
 trap cleanup SIGINT
@@ -31,21 +31,23 @@ if command -v cosign &> /dev/null
 then
   PUBKEY_DIR=$(mktemp -d)
   PUBKEY_FILE="${PUBKEY_DIR}/cosign.pub"
-  curl -Lo "${PUBKEY_FILE}" https://raw.githubusercontent.com/blue-build/cli/refs/heads/main/cosign.pub
-  cosign verify --key "${PUBKEY_FILE}" "ghcr.io/blue-build/cli:${VERSION}-installer"
+  curl -Lo "${PUBKEY_FILE}" https://raw.githubusercontent.com/${PROJECT}/refs/heads/main/cosign.pub
+  cosign verify --key "${PUBKEY_FILE}" "ghcr.io/${PROJECT}:${VERSION}-installer"
 fi
 
 cr create \
   --pull always \
   --name blue-build-installer \
-  ghcr.io/blue-build/cli:${VERSION}-installer
+  ghcr.io/${PROJECT}:${VERSION}-installer
 
 set +e
+set -x
 cr cp blue-build-installer:/out/bluebuild /tmp/
 
 sudo mv /tmp/bluebuild /usr/local/bin/
 
 RETVAL=$?
+set +x
 set -e
 
 if [ $RETVAL != 0 ]; then

--- a/integration-tests/Earthfile
+++ b/integration-tests/Earthfile
@@ -90,7 +90,7 @@ init:
         --no-git
 
 legacy-base:
-    FROM ../+blue-build-cli --RELEASE=false
+    FROM ../+blue-build-cli
     ENV BB_TEST_LOCAL_IMAGE=localhost/cli/test:latest
     ENV CLICOLOR_FORCE=1
 
@@ -105,7 +105,7 @@ legacy-base:
     ENV USER=root
 
 test-base:
-    FROM ../+blue-build-cli --RELEASE=false
+    FROM ../+blue-build-cli
     RUN git config --global user.email "you@example.com" && \
         git config --global user.name "Your Name"
 

--- a/integration-tests/legacy-test-repo/config/recipe.yml
+++ b/integration-tests/legacy-test-repo/config/recipe.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-legacy
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-legacy
 description: This is my personal OS image.
 base-image: ghcr.io/ublue-os/silverblue-surface
 image-version: gts

--- a/integration-tests/test-repo/recipes/recipe-arm64.yml
+++ b/integration-tests/test-repo/recipes/recipe-arm64.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-arm64
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-arm64
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-bluefin.yml
+++ b/integration-tests/test-repo/recipes/recipe-bluefin.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-bluefin
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-bluefin
 description: This is my personal OS image.
 base-image: ghcr.io/ublue-os/bluefin
 blue-build-tag: none

--- a/integration-tests/test-repo/recipes/recipe-build-chunked-oci.yml
+++ b/integration-tests/test-repo/recipes/recipe-build-chunked-oci.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-build-chunked-oci
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-build-chunked-oci
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-buildah.yml
+++ b/integration-tests/test-repo/recipes/recipe-buildah.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-buildah
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-buildah
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-chunkah.yml
+++ b/integration-tests/test-repo/recipes/recipe-chunkah.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-chunkah
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-chunkah
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-docker-external.yml
+++ b/integration-tests/test-repo/recipes/recipe-docker-external.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-docker-external
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-docker-external
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-env-expansion.yml
+++ b/integration-tests/test-repo/recipes/recipe-env-expansion.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-${NAME_EXT:-env-expansion}
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-${NAME_EXT:-env-expansion}
 description: This is my personal OS image. ${DESC_EXT}
 base-image: ${BASE_REGISTRY:-quay.io}/fedora/fedora-bootc
 blue-build-tag: none

--- a/integration-tests/test-repo/recipes/recipe-gts.yml
+++ b/integration-tests/test-repo/recipes/recipe-gts.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test
+name: ${BB_TEST_IMAGE_NAME:-cli}/test
 description: This is my personal OS image.
 base-image: ghcr.io/ublue-os/silverblue-main
 nushell-version: none

--- a/integration-tests/test-repo/recipes/recipe-multiplatform-build-chunked-oci.yml
+++ b/integration-tests/test-repo/recipes/recipe-multiplatform-build-chunked-oci.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-multiplatform-build-chunked-oci
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-multiplatform-build-chunked-oci
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-multiplatform-buildah.yml
+++ b/integration-tests/test-repo/recipes/recipe-multiplatform-buildah.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-multiplatform-buildah
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-multiplatform-buildah
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-multiplatform-chunkah.yml
+++ b/integration-tests/test-repo/recipes/recipe-multiplatform-chunkah.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-multiplatform-chunkah
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-multiplatform-chunkah
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-multiplatform-docker.yml
+++ b/integration-tests/test-repo/recipes/recipe-multiplatform-docker.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-multiplatform-docker
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-multiplatform-docker
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-multiplatform-podman.yml
+++ b/integration-tests/test-repo/recipes/recipe-multiplatform-podman.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-multiplatform-podman
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-multiplatform-podman
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-multiplatform-rechunk.yml
+++ b/integration-tests/test-repo/recipes/recipe-multiplatform-rechunk.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-multiplatform-rechunk
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-multiplatform-rechunk
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-podman.yml
+++ b/integration-tests/test-repo/recipes/recipe-podman.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-podman
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-podman
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-rechunk.yml
+++ b/integration-tests/test-repo/recipes/recipe-rechunk.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test-rechunk
+name: ${BB_TEST_IMAGE_NAME:-cli}/test-rechunk
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 image-version: latest

--- a/integration-tests/test-repo/recipes/recipe-v2.yml
+++ b/integration-tests/test-repo/recipes/recipe-v2.yml
@@ -7,7 +7,7 @@ base:
     repository: fedora/fedora-bootc
     tag: latest
 metadata:
-  name: cli/test-recipe-v2
+  name: ${BB_TEST_IMAGE_NAME:-cli}/test-recipe-v2
   description: This is my personal OS image.
 spec:
   tool-versions:

--- a/integration-tests/test-repo/recipes/recipe.yml
+++ b/integration-tests/test-repo/recipes/recipe.yml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://schema.blue-build.org/recipe-v1.json
-name: cli/test
+name: ${BB_TEST_IMAGE_NAME:-cli}/test
 description: This is my personal OS image.
 base-image: quay.io/fedora/fedora-bootc
 blue-build-tag: none

--- a/justfile
+++ b/justfile
@@ -88,6 +88,34 @@ watch-lint:
 watch-lint-all-features:
   cargo watch -c -x 'clippy --all-features'
 
+# Build the images and store locally
+image-build:
+  earth --output --ci -P +build-images-all
+
+image-prebuild:
+  earth --ci +prebuild
+
+image-prebuild-publish:
+  earth --ci --push +prebuild
+
+image-pulish: && image-digest
+  earth \
+    --push --ci -P +build-images-all \
+    --SIGN="true" \
+    --RELEASE="true"
+
+image-sign-publish: && image-digest
+  earth \
+    --secret COSIGN_PRIVATE_KEY \
+    --secret GH_ACTOR \
+    --secret GH_TOKEN \
+    --push --ci -P +build-images-all \
+    --SIGN="true" \
+    --RELEASE="true"
+
+image-digest:
+  earth +local-digest-list
+
 # Expand the macros of a module for debugging
 expand *args:
   cargo expand $@ > ./expand.rs

--- a/justfile
+++ b/justfile
@@ -91,7 +91,7 @@ watch-lint-all-features:
 
 # Build the images and store locally
 image-build:
-  earth --output --platform native --ci -P +build-images-all
+  earth --output --platform native --ci -P +build-images
 
 image-prebuild:
   earth --ci +prebuild

--- a/justfile
+++ b/justfile
@@ -98,7 +98,7 @@ image-prebuild:
 image-prebuild-publish:
   earth --ci --push +prebuild
 
-image-pulish: && image-digest
+image-publish: && image-digest
   earth \
     --push --ci -P +build-images-all \
     --SIGN="true" \

--- a/justfile
+++ b/justfile
@@ -91,7 +91,7 @@ watch-lint-all-features:
 
 # Build the images and store locally
 image-build:
-  earth --output --ci -P +build-images-all
+  earth --output --platform native --ci -P +build-images-all
 
 image-prebuild:
   earth --ci +prebuild

--- a/justfile
+++ b/justfile
@@ -167,9 +167,9 @@ should_not_sign := if env('COSIGN_PRIVATE_KEY', '') == '' {
 project_path := `git remote get-url origin | sed -E 's|^[^:/]+://[^/]*/||; s|^.*:||; s/\.git$//'`
 
 cargo_bin := if env('CARGO_HOME', '') != '' {
-  x"${CARGO_HOME:-}/bin"
+  x"${CARGO_HOME:-}/bin/bluebuild"
 } else {
-  x"$HOME/.cargo/bin"
+  x"$HOME/.cargo/bin/bluebuild"
 }
 
 generate-test-secret:
@@ -182,7 +182,7 @@ integration-tests: generate-test-secret test-docker-build test-empty-files-build
 # Run docker driver integration test
 test-docker-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B docker \
     -S sigstore \
@@ -193,7 +193,7 @@ test-docker-build: generate-test-secret install-debug-all-features
 
 test-recipe-v2-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -S sigstore \
     {{ should_push }} \
@@ -203,7 +203,7 @@ test-recipe-v2-build: generate-test-secret install-debug-all-features
 
 test-empty-files-build: generate-test-secret install-debug-all-features
   cd integration-tests/empty-files-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B docker \
     -S sigstore \
@@ -215,7 +215,7 @@ test-env-expansion-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
   && DESC_EXT="Test description" \
   VERSION="43" \
-  bluebuild build \
+  {{ cargo_bin }} build \
     --retry-push \
     -B docker \
     -S sigstore \
@@ -226,7 +226,7 @@ test-env-expansion-build: generate-test-secret install-debug-all-features
 
 test-bluefin-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B docker \
     -S sigstore \
@@ -237,7 +237,7 @@ test-bluefin-build: generate-test-secret install-debug-all-features
 
 test-chunkah-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     {{ should_push }} \
     {{ should_not_sign }} \
     -vv \
@@ -246,7 +246,7 @@ test-chunkah-build: generate-test-secret install-debug-all-features
 
 test-build-chunked-oci-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     {{ should_push }} \
     {{ should_not_sign }} \
     -vv \
@@ -255,7 +255,7 @@ test-build-chunked-oci-build: generate-test-secret install-debug-all-features
 
 test-rechunk-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     {{ should_push }} \
     {{ should_not_sign }} \
     -vv \
@@ -264,7 +264,7 @@ test-rechunk-build: generate-test-secret install-debug-all-features
 
 test-fresh-rechunk-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     {{ should_push }} \
     {{ should_not_sign }} \
     -vv \
@@ -275,7 +275,7 @@ test-fresh-rechunk-build: generate-test-secret install-debug-all-features
 # Run arm integration test
 test-arm64-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     --platform linux/arm64 \
     {{ should_push }} \
@@ -286,7 +286,7 @@ test-arm64-build: generate-test-secret install-debug-all-features
 # Run docker driver external login integration test
 test-docker-build-external-login: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -S sigstore \
     {{ should_push }} \
@@ -297,7 +297,7 @@ test-docker-build-external-login: generate-test-secret install-debug-all-feature
 # Run podman driver integration test
 test-podman-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B podman \
     -S sigstore \
@@ -309,7 +309,7 @@ test-podman-build: generate-test-secret install-debug-all-features
 # Run buildah driver integration test
 test-buildah-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B buildah \
     -S sigstore \
@@ -323,7 +323,7 @@ test-multiplatform: test-multiplatform-docker test-multiplatform-podman test-mul
 
 test-multiplatform-docker: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B docker \
     -S sigstore \
@@ -334,7 +334,7 @@ test-multiplatform-docker: generate-test-secret install-debug-all-features
 
 test-multiplatform-podman: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B podman \
     -S sigstore \
@@ -345,7 +345,7 @@ test-multiplatform-podman: generate-test-secret install-debug-all-features
 
 test-multiplatform-buildah: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     -B buildah \
     -S sigstore \
@@ -356,7 +356,7 @@ test-multiplatform-buildah: generate-test-secret install-debug-all-features
 
 test-multiplatform-chunkah: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     --chunkah \
     --remove-base-image \
@@ -368,7 +368,7 @@ test-multiplatform-chunkah: generate-test-secret install-debug-all-features
 
 test-multiplatform-build-chunked-oci: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     --build-chunked-oci \
     --remove-base-image \
@@ -380,7 +380,7 @@ test-multiplatform-build-chunked-oci: generate-test-secret install-debug-all-fea
 
 test-multiplatform-rechunk: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
-  && bluebuild build \
+  && {{ cargo_bin }} build \
     --retry-push \
     --rechunk \
     -S sigstore \
@@ -394,14 +394,14 @@ test-generate-iso-image: generate-test-secret install-debug-all-features
   #!/usr/bin/env bash
   set -eu
   ISO_OUT=$(mktemp -d)
-  bluebuild generate-iso -vv --output-dir "$ISO_OUT" image ghcr.io/{{ project_path }}/test:latest
+  {{ cargo_bin }} generate-iso -vv --output-dir "$ISO_OUT" image ghcr.io/{{ project_path }}/test:latest
 
 # Run ISO generator for images using web-ui
 test-generate-iso-web-ui: generate-test-secret install-debug-all-features
   #!/usr/bin/env bash
   set -eu
   ISO_OUT=$(mktemp -d)
-  bluebuild generate-iso -vv --output-dir "$ISO_OUT" --web-ui image ghcr.io/{{ project_path }}/test:latest
+  {{ cargo_bin }} generate-iso -vv --output-dir "$ISO_OUT" --web-ui image ghcr.io/{{ project_path }}/test:latest
 
 # Run ISO generator for images
 test-generate-iso-recipe: generate-test-secret install-debug-all-features
@@ -409,7 +409,7 @@ test-generate-iso-recipe: generate-test-secret install-debug-all-features
   set -eu
   ISO_OUT=$(mktemp -d)
   cd integration-tests/test-repo
-  bluebuild generate-iso -vv --output-dir "$ISO_OUT" recipe recipes/recipe.yml
+  {{ cargo_bin }} generate-iso -vv --output-dir "$ISO_OUT" recipe recipes/recipe.yml
 
 # Build a local cli image
 build-local-cli-image:

--- a/justfile
+++ b/justfile
@@ -151,8 +151,12 @@ release *args:
   git push origin "v${VERSION}"
   gh release create --generate-notes --latest "v${VERSION}"
 
-should_push := if env('GITHUB_ACTIONS', '') != '' && env('GH_TOKEN', '') != '' {
-  '--push'
+should_push := if env('GITHUB_ACTIONS', '') != '' {
+  if env('GH_TOKEN', '') != '' {
+    '--push'
+  } else {
+    ''
+  }
 } else {
   ''
 }

--- a/justfile
+++ b/justfile
@@ -102,7 +102,6 @@ image-prebuild-publish:
 image-publish: && image-digest
   earth \
     --push --ci -P +build-images-all \
-    --SIGN="true" \
     --RELEASE="true"
 
 image-sign-publish: && image-digest

--- a/justfile
+++ b/justfile
@@ -172,6 +172,8 @@ cargo_bin := if env('CARGO_HOME', '') != '' {
   x"$HOME/.cargo/bin/bluebuild"
 }
 
+export BB_TEST_IMAGE_NAME := file_stem(project_path)
+
 generate-test-secret:
   mkdir -p integration-tests/test-repo/secrets
   echo "321tset" > integration-tests/test-repo/secrets/test-secret

--- a/justfile
+++ b/justfile
@@ -151,7 +151,7 @@ release *args:
   git push origin "v${VERSION}"
   gh release create --generate-notes --latest "v${VERSION}"
 
-should_push := if env('GITHUB_ACTIONS', '') != '' {
+should_push := if env('GITHUB_ACTIONS', '') != '' && env('GH_TOKEN', '') != '' {
   '--push'
 } else {
   ''

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ export BB_SKIP_VALIDATION := "true"
 
 set dotenv-load := true
 set positional-arguments := true
+set lazy
 
 # default recipe to display help information
 default:
@@ -152,14 +153,18 @@ release *args:
   gh release create --generate-notes --latest "v${VERSION}"
 
 should_push := if env('GITHUB_ACTIONS', '') != '' {
-  if env('COSIGN_PRIVATE_KEY', '') != '' {
-    '--push'
-  } else {
-    ''
-  }
+  '--push'
 } else {
   ''
 }
+
+should_not_sign := if env('COSIGN_PRIVATE_KEY', '') == '' {
+  '--no-sign'
+} else {
+  ''
+}
+
+project_path := `git remote get-url origin | sed -E 's|^[^:/]+://[^/]*/||; s|^.*:||; s/\.git$//'`
 
 cargo_bin := if env('CARGO_HOME', '') != '' {
   x"${CARGO_HOME:-}/bin"
@@ -182,6 +187,7 @@ test-docker-build: generate-test-secret install-debug-all-features
     -B docker \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe.yml recipes/recipe-gts.yml
 
@@ -191,6 +197,7 @@ test-recipe-v2-build: generate-test-secret install-debug-all-features
     --retry-push \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-v2.yml
 
@@ -201,6 +208,7 @@ test-empty-files-build: generate-test-secret install-debug-all-features
     -B docker \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv
 
 test-env-expansion-build: generate-test-secret install-debug-all-features
@@ -212,6 +220,7 @@ test-env-expansion-build: generate-test-secret install-debug-all-features
     -B docker \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-env-expansion.yml
 
@@ -222,6 +231,7 @@ test-bluefin-build: generate-test-secret install-debug-all-features
     -B docker \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-bluefin.yml
 
@@ -229,6 +239,7 @@ test-chunkah-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
   && bluebuild build \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     --chunkah \
     recipes/recipe-chunkah.yml
@@ -237,6 +248,7 @@ test-build-chunked-oci-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
   && bluebuild build \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     --build-chunked-oci \
     recipes/recipe-build-chunked-oci.yml
@@ -245,6 +257,7 @@ test-rechunk-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
   && bluebuild build \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     --rechunk \
     recipes/recipe-rechunk.yml
@@ -253,6 +266,7 @@ test-fresh-rechunk-build: generate-test-secret install-debug-all-features
   cd integration-tests/test-repo \
   && bluebuild build \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     --rechunk \
     --rechunk-clear-plan \
@@ -265,6 +279,7 @@ test-arm64-build: generate-test-secret install-debug-all-features
     --retry-push \
     --platform linux/arm64 \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-arm64.yml
 
@@ -275,6 +290,7 @@ test-docker-build-external-login: generate-test-secret install-debug-all-feature
     --retry-push \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-docker-external.yml
 
@@ -286,6 +302,7 @@ test-podman-build: generate-test-secret install-debug-all-features
     -B podman \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-podman.yml
 
@@ -297,6 +314,7 @@ test-buildah-build: generate-test-secret install-debug-all-features
     -B buildah \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-buildah.yml
 
@@ -310,6 +328,7 @@ test-multiplatform-docker: generate-test-secret install-debug-all-features
     -B docker \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-multiplatform-docker.yml
 
@@ -320,6 +339,7 @@ test-multiplatform-podman: generate-test-secret install-debug-all-features
     -B podman \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-multiplatform-podman.yml
 
@@ -330,6 +350,7 @@ test-multiplatform-buildah: generate-test-secret install-debug-all-features
     -B buildah \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-multiplatform-buildah.yml
 
@@ -341,6 +362,7 @@ test-multiplatform-chunkah: generate-test-secret install-debug-all-features
     --remove-base-image \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-multiplatform-chunkah.yml
 
@@ -352,6 +374,7 @@ test-multiplatform-build-chunked-oci: generate-test-secret install-debug-all-fea
     --remove-base-image \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-multiplatform-build-chunked-oci.yml
 
@@ -362,6 +385,7 @@ test-multiplatform-rechunk: generate-test-secret install-debug-all-features
     --rechunk \
     -S sigstore \
     {{ should_push }} \
+    {{ should_not_sign }} \
     -vv \
     recipes/recipe-multiplatform-rechunk.yml
 
@@ -370,14 +394,14 @@ test-generate-iso-image: generate-test-secret install-debug-all-features
   #!/usr/bin/env bash
   set -eu
   ISO_OUT=$(mktemp -d)
-  bluebuild generate-iso -vv --output-dir "$ISO_OUT" image ghcr.io/blue-build/cli/test:latest
+  bluebuild generate-iso -vv --output-dir "$ISO_OUT" image ghcr.io/{{ project_path }}/test:latest
 
 # Run ISO generator for images using web-ui
 test-generate-iso-web-ui: generate-test-secret install-debug-all-features
   #!/usr/bin/env bash
   set -eu
   ISO_OUT=$(mktemp -d)
-  bluebuild generate-iso -vv --output-dir "$ISO_OUT" --web-ui image ghcr.io/blue-build/cli/test:latest
+  bluebuild generate-iso -vv --output-dir "$ISO_OUT" --web-ui image ghcr.io/{{ project_path }}/test:latest
 
 # Run ISO generator for images
 test-generate-iso-recipe: generate-test-secret install-debug-all-features
@@ -389,7 +413,7 @@ test-generate-iso-recipe: generate-test-secret install-debug-all-features
 
 # Build a local cli image
 build-local-cli-image:
-  earth --ci --output -P +blue-build-cli --RELEASE='false'
+  earth --ci --output -P +blue-build-cli
 
 git_sha := `git rev-parse HEAD`
 tty_arg := `[ -t 0 ] && echo "t" || echo ""`
@@ -399,7 +423,7 @@ exec-cli-container +args: build-local-cli-image
   docker run -i{{ tty_arg }} --privileged --rm \
     -v ./integration-tests/test-repo:/bluebuild \
     -e TEST_SECRET="$TEST_SECRET" \
-    ghcr.io/blue-build/cli:{{ git_sha }} \
+    ghcr.io/{{ project_path }}:{{ git_sha }} \
     {{ args }}
 
 # Run a cli container using the podman build driver

--- a/process/drivers/github_driver.rs
+++ b/process/drivers/github_driver.rs
@@ -136,8 +136,8 @@ impl CiDriver for GithubDriver {
     fn get_registry() -> miette::Result<String> {
         let event = Event::read_from_env()?;
 
-        let owner = if let Some(head) = event.head {
-            head.repo.owner.login
+        let owner = if let Some(pr) = event.pull_request {
+            pr.head.repo.owner.login
         } else {
             event.repository.owner.login
         };

--- a/process/drivers/github_driver.rs
+++ b/process/drivers/github_driver.rs
@@ -24,6 +24,18 @@ mod event;
 
 pub struct GithubDriver;
 
+impl GithubDriver {
+    fn is_pull_request() -> bool {
+        get_env_var(GITHUB_EVENT_NAME)
+            .inspect(|v| trace!("{GITHUB_EVENT_NAME}={v}"))
+            .is_ok_and(|val| val == "pull_request")
+    }
+
+    fn get_pr_number() -> Result<String> {
+        get_env_var(PR_EVENT_NUMBER).inspect(|v| trace!("{PR_EVENT_NUMBER}={v}"))
+    }
+}
+
 impl CiDriver for GithubDriver {
     fn on_default_branch() -> bool {
         Event::read_from_env().is_ok_and(|e| e.on_default_branch())
@@ -38,7 +50,6 @@ impl CiDriver for GithubDriver {
     }
 
     fn generate_tags(opts: GenerateTagsOpts) -> Result<Vec<Tag>> {
-        const PR_EVENT: &str = "pull_request";
         let timestamp = blue_build_utils::get_tag_timestamp();
         let os_version = Driver::get_os_version()
             .oci_ref(opts.oci_ref)
@@ -56,9 +67,24 @@ impl CiDriver for GithubDriver {
         let tags = match (
             Self::on_default_branch(),
             opts.alt_tags.as_ref(),
-            get_env_var(GITHUB_EVENT_NAME).inspect(|v| trace!("{GITHUB_EVENT_NAME}={v}")),
-            get_env_var(PR_EVENT_NUMBER).inspect(|v| trace!("{PR_EVENT_NUMBER}={v}")),
+            Self::is_pull_request(),
+            Self::get_pr_number(),
         ) {
+            (false, None, true, Ok(event_num)) => {
+                vec![
+                    format!("pr-{event_num}-{os_version}"),
+                    format!("{short_sha}-{os_version}"),
+                ]
+            }
+            (false, Some(alt_tags), true, Ok(event_num)) => alt_tags
+                .iter()
+                .flat_map(|alt| {
+                    vec![
+                        format!("pr-{event_num}-{alt}-{os_version}"),
+                        format!("{short_sha}-{alt}-{os_version}"),
+                    ]
+                })
+                .collect(),
             (true, None, _, _) => {
                 string_vec![
                     "latest",
@@ -79,28 +105,11 @@ impl CiDriver for GithubDriver {
                     ]
                 })
                 .collect(),
-            (false, None, Ok(event_name), Ok(event_num)) if event_name == PR_EVENT => {
-                vec![
-                    format!("pr-{event_num}-{os_version}"),
-                    format!("{short_sha}-{os_version}"),
-                ]
-            }
             (false, None, _, _) => {
                 vec![
                     format!("br-{ref_name}-{os_version}"),
                     format!("{short_sha}-{os_version}"),
                 ]
-            }
-            (false, Some(alt_tags), Ok(event_name), Ok(event_num)) if event_name == PR_EVENT => {
-                alt_tags
-                    .iter()
-                    .flat_map(|alt| {
-                        vec![
-                            format!("pr-{event_num}-{alt}-{os_version}"),
-                            format!("{short_sha}-{alt}-{os_version}"),
-                        ]
-                    })
-                    .collect()
             }
             (false, Some(alt_tags), _, _) => alt_tags
                 .iter()
@@ -125,11 +134,14 @@ impl CiDriver for GithubDriver {
     }
 
     fn get_registry() -> miette::Result<String> {
-        Ok(
-            format!("ghcr.io/{}", Event::read_from_env()?.repository.owner.login)
-                .trim()
-                .to_lowercase(),
-        )
+        let event = Event::read_from_env()?;
+
+        let owner = if let Some(head) = event.head {
+            head.repo.owner.login
+        } else {
+            event.repository.owner.login
+        };
+        Ok(format!("ghcr.io/{owner}").trim().to_lowercase())
     }
 
     fn default_ci_file_path() -> PathBuf {
@@ -194,12 +206,21 @@ mod test {
     }
 
     #[test]
-    fn get_registry() {
+    fn get_registry_default_branch() {
         setup_default_branch();
 
         let registry = GithubDriver::get_registry().unwrap();
 
         assert_eq!(registry, "ghcr.io/test-owner");
+    }
+
+    #[test]
+    fn get_registry_pr() {
+        setup_pr_branch();
+
+        let registry = GithubDriver::get_registry().unwrap();
+
+        assert_eq!(registry, "ghcr.io/gmpinder");
     }
 
     #[test]

--- a/process/drivers/github_driver.rs
+++ b/process/drivers/github_driver.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use blue_build_utils::{
     constants::{
-        GITHUB_EVENT_NAME, GITHUB_EVENT_PATH, GITHUB_REF_NAME, GITHUB_SHA, GITHUB_TOKEN_ISSUER_URL,
+        GITHUB_EVENT_NAME, GITHUB_REF_NAME, GITHUB_SHA, GITHUB_TOKEN_ISSUER_URL,
         GITHUB_WORKFLOW_REF, PR_EVENT_NUMBER,
     },
     container::Tag,
@@ -26,8 +26,7 @@ pub struct GithubDriver;
 
 impl CiDriver for GithubDriver {
     fn on_default_branch() -> bool {
-        get_env_var(GITHUB_EVENT_PATH)
-            .is_ok_and(|path| Event::try_new(path).is_ok_and(|e| e.on_default_branch()))
+        Event::read_from_env().is_ok_and(|e| e.on_default_branch())
     }
 
     fn keyless_cert_identity() -> Result<String> {
@@ -122,21 +121,15 @@ impl CiDriver for GithubDriver {
     }
 
     fn get_repo_url() -> miette::Result<String> {
-        Ok(Event::try_new(get_env_var(GITHUB_EVENT_PATH)?)?
-            .repository
-            .html_url)
+        Ok(Event::read_from_env()?.repository.html_url)
     }
 
     fn get_registry() -> miette::Result<String> {
-        Ok(format!(
-            "ghcr.io/{}",
-            Event::try_new(get_env_var(GITHUB_EVENT_PATH)?)?
-                .repository
-                .owner
-                .login
+        Ok(
+            format!("ghcr.io/{}", Event::read_from_env()?.repository.owner.login)
+                .trim()
+                .to_lowercase(),
         )
-        .trim()
-        .to_lowercase())
     }
 
     fn default_ci_file_path() -> PathBuf {

--- a/process/drivers/github_driver/event.rs
+++ b/process/drivers/github_driver/event.rs
@@ -17,6 +17,8 @@ pub(super) struct Event {
     // pub base: Option<EventRefInfo>,
     pub head: Option<EventRefInfo>,
 
+    pub pull_request: Option<EventPullRequest>,
+
     #[serde(alias = "ref")]
     pub commit_ref: Option<String>,
 }
@@ -72,6 +74,11 @@ pub(super) struct EventRepository {
 #[derive(Debug, Deserialize, Clone)]
 pub(super) struct EventRepositoryOwner {
     pub login: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub(super) struct EventPullRequest {
+    pub head: EventRefInfo,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/process/drivers/github_driver/event.rs
+++ b/process/drivers/github_driver/event.rs
@@ -37,6 +37,7 @@ impl Event {
                 .into_diagnostic()
                 .inspect(|event| trace!("{event}"))
                 .and_then(|event| serde_json::from_str(&event).into_diagnostic())
+                .inspect(|event| trace!("{event:#?}"))
         }
         get_env_var(GITHUB_EVENT_PATH)
             .map(PathBuf::from)
@@ -77,6 +78,7 @@ pub(super) struct EventRepositoryOwner {
 pub(super) struct EventRefInfo {
     #[serde(alias = "ref")]
     pub commit_ref: String,
+    pub repo: EventRepository,
 }
 
 #[cfg(test)]

--- a/process/drivers/github_driver/event.rs
+++ b/process/drivers/github_driver/event.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
+use std::{fs, path::PathBuf};
 
-use blue_build_utils::constants::GITHUB_REF_NAME;
-use log::debug;
-use miette::{Context, IntoDiagnostic, Result};
+use blue_build_utils::constants::{GITHUB_EVENT_PATH, GITHUB_REF_NAME};
+use log::{debug, trace};
+use miette::{IntoDiagnostic, Result};
 use serde::Deserialize;
 
 #[cfg(test)]
@@ -21,26 +21,26 @@ pub(super) struct Event {
     pub commit_ref: Option<String>,
 }
 
-impl TryFrom<&str> for Event {
-    type Error = miette::Report;
-
-    fn try_from(value: &str) -> std::prelude::v1::Result<Self, Self::Error> {
-        serde_json::from_str(value).into_diagnostic()
-    }
-}
-
 impl Event {
-    pub fn try_new<P>(path: P) -> Result<Self>
-    where
-        P: AsRef<Path>,
-    {
-        fn inner(path: &Path) -> Result<Event> {
-            let contents = std::fs::read_to_string(path)
+    /// Reads from the environment and constructs
+    /// itself from the event file.
+    ///
+    /// # Errors
+    /// Will error if the environment variable
+    /// `GITHUB_EVENT_PATH` doesn't exist or if
+    /// deserializing the event file fails.
+    pub fn read_from_env() -> Result<Self> {
+        // We cache since the event won't change during evocation
+        #[cached::cached()]
+        fn inner(path: PathBuf) -> Result<Event> {
+            fs::read_to_string(path)
                 .into_diagnostic()
-                .with_context(|| format!("Path: {}", path.display()))?;
-            Event::try_from(contents.as_str())
+                .inspect(|event| trace!("{event}"))
+                .and_then(|event| serde_json::from_str(&event).into_diagnostic())
         }
-        inner(path.as_ref())
+        get_env_var(GITHUB_EVENT_PATH)
+            .map(PathBuf::from)
+            .and_then(inner)
     }
 
     pub fn on_default_branch(&self) -> bool {
@@ -60,17 +60,6 @@ impl Event {
         }
     }
 }
-
-// impl Event {
-//     pub fn try_new() -> Result<Self> {
-//         get_env_var(GITHUB_EVENT_PATH)
-//             .map(PathBuf::from)
-//             .and_then(|event_path| {
-//                 serde_json::from_str::<Self>(&fs::read_to_string(event_path).into_diagnostic()?)
-//                     .into_diagnostic()
-//             })
-//     }
-// }
 
 #[derive(Debug, Deserialize, Clone)]
 pub(super) struct EventRepository {
@@ -92,7 +81,10 @@ pub(super) struct EventRefInfo {
 
 #[cfg(test)]
 mod test {
-    use blue_build_utils::{constants::GITHUB_REF_NAME, test_utils::set_env_var};
+    use blue_build_utils::{
+        constants::{GITHUB_EVENT_PATH, GITHUB_REF_NAME},
+        test_utils::set_env_var,
+    };
     use rstest::rstest;
 
     use super::Event;
@@ -103,9 +95,10 @@ mod test {
     #[case::pr("../test-files/github-events/pr-branch.json", "test", false)]
     #[case::branch("../test-files/github-events/branch.json", "test", false)]
     fn test_on_default_branch(#[case] path: &str, #[case] ref_name: &str, #[case] expected: bool) {
+        set_env_var(GITHUB_EVENT_PATH, path);
         set_env_var(GITHUB_REF_NAME, ref_name);
 
-        let event = Event::try_new(path).unwrap();
+        let event = Event::read_from_env().unwrap();
         eprintln!("{event:?}");
 
         assert_eq!(expected, event.on_default_branch());

--- a/test-files/github-events/pr-branch.json
+++ b/test-files/github-events/pr-branch.json
@@ -1,16 +1,18 @@
 {
-    "head": {
-        "ref": "test-branch",
-        "repo": {
-            "default_branch": "main",
-            "owner": {
-                "login": "gmpinder"
-            },
-            "html_url": "https://example.com/"
+    "pull_request": {
+        "head": {
+            "ref": "test-branch",
+            "repo": {
+                "default_branch": "main",
+                "owner": {
+                    "login": "gmpinder"
+                },
+                "html_url": "https://example.com/"
+            }
+        },
+        "base": {
+            "ref": "main"
         }
-    },
-    "base": {
-        "ref": "main"
     },
     "repository": {
         "default_branch": "main",

--- a/test-files/github-events/pr-branch.json
+++ b/test-files/github-events/pr-branch.json
@@ -1,15 +1,22 @@
 {
-  "head": {
-    "ref": "test-branch"
-  },
-  "base": {
-    "ref": "main"
-  },
-  "repository": {
-    "default_branch": "main",
-    "owner": {
-      "login": "Test-Owner"
+    "head": {
+        "ref": "test-branch",
+        "repo": {
+            "default_branch": "main",
+            "owner": {
+                "login": "gmpinder"
+            },
+            "html_url": "https://example.com/"
+        }
     },
-    "html_url": "https://example.com/"
-  }
+    "base": {
+        "ref": "main"
+    },
+    "repository": {
+        "default_branch": "main",
+        "owner": {
+            "login": "Test-Owner"
+        },
+        "html_url": "https://example.com/"
+    }
 }


### PR DESCRIPTION
This PR allows other developers to easily fork the CLI repo, build, and publish their own images to test their changes. Several types of changes were made to support this.

## Earthfile

By refactoring the Earthfile to make use of `EARTH_GIT_PROJECT_NAME` built-in arg, we can publish the build image to the user's own container registry. The labels are also updated to make use of this arg so that images are appropriately tied back to the forked repo. Some `justfile` recipes were also added to make calling them easier in the workflow files.

## GHA Workflows

The action workflows were also refactored to consolidate all the repeated jobs defined in each job in `test.yml`. There were some inputs added to trigger installing certain tools for different test scenarios like docker, qemu, or earthbuild. There is a particular input that gets passed in to make dealing with forks easier called `fork_pr`, the value of which is calculated from a higher workflow file. This flag is used to flip certain jobs on and off to disable pushing images since fork PR GitHub Action tokens do not appear to have the ability to authorize pushing to either the head repo's registry or the base repo's.

Forks should always be able to build and publish images when not running the jobs in a PR against the main repo.

## Integration Test Recipe files

The integration test recipes were originally setup to push to the `cli/{test_scenario}` image repository. Not every dev will fork to a repo named `cli`, so I added some logic in the `justfile` to retrieve the repository name and set it to `BB_TEST_IMAGE_NAME`. This is then used in the recipes using the environment variable expansion feature (#749) to rename the image to match the dev's name for the forked repo.

## GitHub Driver

I found a logic error in the `github_driver` that was not properly detecting when a build was running in a PR. I made sure to update the logic so that the `head` of the PR is used when obtaining information about the build to keep in line with the other logic setup above.

Closes #802 